### PR TITLE
refactor: more stable rendering of controls

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -135,7 +135,7 @@ function moveCarousel($block, increment) {
   toggleControls($block, newLeft);
 }
 
-async function buildCarousel($block) {
+function buildCarousel($block) {
   // add templates to carousel
   const $platform = createTag('div', { class: 'carousel-platform' });
   Array.from($block.children).forEach((t) => $platform.appendChild(t));
@@ -281,8 +281,8 @@ async function decorateTemplateList($block) {
     /* flex masonry */
     // console.log(`masonry-rows: ${rows}`);
     const $masonryCells = Array.from($block.children);
-    // $block.classList.remove('masonry');
-    // $block.classList.add('flex-masonry');
+    $block.classList.remove('masonry');
+    $block.classList.add('flex-masonry');
     masonrize($masonryCells, $block);
     window.addEventListener('resize', () => {
       masonrize($masonryCells, $block);


### PR DESCRIPTION
While testing with slower connection, I noticed that sometimes the arrow controls aren't drawn even thought eh width of the media in the carousel would require it. They are shown depending on the width of the carousel slider which in turn relies on the images and videos being loaded. This change waits for the media to be loaded before deciding to show any controls. Also, they get re-evaluated on window.resize now.