### PR TITLE
feat(fragment): initial fragment implementation

### DIFF
--- a/express/blocks/fragment/fragment.js
+++ b/express/blocks/fragment/fragment.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* global fetch */
+/* eslint-disable import/named, import/extensions */
+
+import {
+  createTag,
+  decorateMain,
+  loadBlocks,
+} from '../../scripts/scripts.js';
+
+async function decorateFragment($block) {
+  const ref = $block.textContent;
+  console.log(ref);
+  const path = new URL(ref).pathname.split('.')[0];
+  const resp = await fetch(`${path}.plain.html`);
+  const html = await resp.text();
+  const $main = createTag('main');
+  $main.innerHTML = html;
+  decorateMain($main);
+  loadBlocks($main);
+  $block.parentNode.replaceChild($main, $block);
+}
+
+export default function decorate($block) {
+  decorateFragment($block);
+}


### PR DESCRIPTION
initial implementation of a general purpose `fragment` block...

https://block-fragment--express-website--adobe.hlx.page/drafts/uncled/test1

i think this needs to be a little bit more context sensitive, not sure yet how.

i think there are usecases where 
(1) we really just want to replace the fragment block with what's in the fragment (or in the section of the fragment) and 
(2) there are usecases where we want to split the fragment into its own section and replace the section with all the sections in the fragment.

intuitively i would say that this could be triggered by the number of sections in the fragment, but that seems somewhat weird as well especially in case (2) it is conceivable that there are fragments with one or many section. configuring this on the `fragment` block seems easy and intuitive (eg. with a variant) but at the same time it is probably redundant, as i cannot imagine the same fragment content to be used in a (1) and (2) context.