### PR TITLE
feat: add new search query param to edit template href

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -235,7 +235,9 @@ export async function decorateTemplateList($block) {
       if ($link.href) {
         const url = new URL($link.href);
         const params = url.searchParams;
-        params.set('search', templateSearchTag);
+        if (templateSearchTag) {
+          params.set('search', templateSearchTag);
+        }
         url.search = params.toString();
 
         $a = createTag('a', {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes to add a new query parameter `search` to "Edit this template" href to enable template filtering in the Spark Editor

## Related Issue
https://github.com/adobe/express-website/issues/94

## Motivation and Context
We currently navigate users to the Spark editor when they click on "Edit this template" without any context about the current page. By passing context about the template to the editor through a new query parameter, we can use it to pre-filter templates in the editor. The title for the templates in the page is already part of the page metadata as short-title.

## How Has This Been Tested?
I tested these changes locally by navigating to `express/create/` pages and clicking on "Edit this template". I verified that the editor url has the correct `?search=` parameter

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
