### PR TITLE
fix: href text content check and editor link check

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -13,7 +13,7 @@
           FontFace, sessionStorage, Image */
 /* eslint-disable no-console */
 
-const postEditorLinksAllowList = ['adobesparkpost.app.link', 'spark.adobe.com/sp/design'];
+const postEditorLinksAllowList = ['adobesparkpost.app.link', 'spark.adobe.com/sp/design', 'express.adobe.com/sp/design'];
 
 export function addPublishDependencies(url) {
   if (!Array.isArray(url)) {


### PR DESCRIPTION
Changes to fix https://github.com/adobe/express-website/issues/105

- Fixes the `$a.href !== $a.textContent` check by using the original href instead of the decorated href
- Adds new check to only decorate urls pointing to the post editor