### PR TITLE
fix(link-list): regression

### DIFF
--- a/express/blocks/link-list/link-list.css
+++ b/express/blocks/link-list/link-list.css
@@ -21,13 +21,8 @@ main .link-list p.button-container {
   margin: 0;
 }
 
-main .link-list a.button.small.secondary {
+main .link-list a.button.secondary {
   margin: 6px 20px 6px 0;
-}
-
-main .link-list a.button.small.secondary:hover {
-  background-color: var(--color-black);
-  color: var(--color-white);
 }
 
 main .link-list .link-list-carousel-platform {


### PR DESCRIPTION
With the switch from `small` to `medium` buttons, we lost 2 button rules:
1. margins: added back (for all button sizes)
2. hover state (removed per discussion with @skelleyadobe)