### PR TITLE
fix: template-list decoration is async

### DIFF
--- a/express/blocks/page-list/page-list.js
+++ b/express/blocks/page-list/page-list.js
@@ -70,7 +70,7 @@ async function appendTemplates($row) {
     }
   });
   $row.append($tlBlock);
-  decorateTemplateList($tlBlock);
+  return decorateTemplateList($tlBlock);
 }
 
 async function outputPages(pages, $block) {
@@ -141,6 +141,6 @@ async function decoratePageList($block) {
   $block.classList.add('appear');
 }
 
-export default function decorate($block) {
-  decoratePageList($block);
+export default async function decorate($block) {
+  return decoratePageList($block);
 }

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -309,6 +309,6 @@ export async function decorateTemplateList($block) {
   }
 }
 
-export default function decorate($block) {
-  decorateTemplateList($block);
+export default async function decorate($block) {
+  return decorateTemplateList($block);
 }


### PR DESCRIPTION
This addresses multiple issues with the template-list, like missing blueprint template list on locale pages (https://main--express-website--adobe.hlx3.page/es/express/feature/image/brighten) from time to time.