### PR TITLE
fix: broken carousel

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -529,14 +529,17 @@ export function decorateBlocks($main) {
     }
     const blocksWithOptions = ['checker-board', 'template-list', 'steps', 'cards', 'quotes', 'page-list',
       'columns', 'show-section-only', 'image-list', 'feature-list', 'icon-list', 'table-of-contents', 'how-to-steps'];
-    blocksWithOptions.forEach((b) => {
-      if (blockName.startsWith(`${b}-`)) {
-        const options = blockName.substring(b.length + 1).split('-').filter((opt) => !!opt);
-        blockName = b;
-        $block.classList.add(b);
-        $block.classList.add(...options);
-      }
-    });
+
+    if (blockName !== 'how-to-steps-carousel') {
+      blocksWithOptions.forEach((b) => {
+        if (blockName.startsWith(`${b}-`)) {
+          const options = blockName.substring(b.length + 1).split('-').filter((opt) => !!opt);
+          blockName = b;
+          $block.classList.add(b);
+          $block.classList.add(...options);
+        }
+      });
+    }
     $block.classList.add('block');
     $block.setAttribute('data-block-name', blockName);
   });


### PR DESCRIPTION
Regression introduce by #148: `how-to-steps-carousels` "looks" like an option of `how-to-steps`. Unfortunate option handling mechanism. I checked to make a better fix but blocks do not treat the options the same way. Changing the global block logic is too risky.

Forward port of https://github.com/adobe/spark-website/pull/206

cc @davidnuescheler 