### PR TITLE
fix(columns): limit brand icon to fullsize columns

### DIFF
--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -15,8 +15,10 @@ import { linkImage, createTag, transformLinkToAnimation } from '../../scripts/sc
 
 function decorateIconList($columnCell) {
   const icons = $columnCell.querySelectorAll('img.icon, svg.icon');
-  if (icons.length === 1 && icons[0].closest('p').innerText === '') {
-    // treat single icon without text as brand icon
+  if (icons.length === 1
+    && icons[0].closest('p').innerText === ''
+    && $columnCell.closest('.columns.fullsize')) {
+    // treat single icon without text in a fullsize column cell as brand icon
     icons[0].classList.add('brand');
     return;
   }


### PR DESCRIPTION
Fix https://github.com/adobe/express-website-issues/issues/201

Before: https://main--express-website--adobe.hlx3.page/drafts/rofe/brand-icon
After: https://issue-201--express-website--adobe.hlx3.page/drafts/rofe/brand-icon