### PR TITLE
chore: remove sign-in on non US locales

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -546,7 +546,7 @@ function decorateHeaderAndFooter() {
     $header.innerHTML = html;
   } else {
     $header.innerHTML = getGnavPlaceholder({
-      signIn: 'Sign In',
+      signIn: '',
       signInLink: 'https://express.adobe.com/sp/',
       top: [],
     });


### PR DESCRIPTION
fixes: https://github.com/adobe/express-website-issues/issues/207

https://main--express-website--adobe.hlx3.page/es/express/

vs. 

https://signin-flash--express-website--adobe.hlx3.page/es/express/