### PR TITLE
chore: remove loop from hero-animation

### DIFF
--- a/express/blocks/hero-animation/hero-animation.js
+++ b/express/blocks/hero-animation/hero-animation.js
@@ -27,7 +27,7 @@ function timecodeToSeconds(timecode) {
 
 function createAnimation(animations) {
   const attribs = {};
-  ['playsinline', 'autoplay', 'loop', 'muted'].forEach((p) => {
+  ['playsinline', 'autoplay', 'muted'].forEach((p) => {
     attribs[p] = '';
   });
 


### PR DESCRIPTION
removing loop from hero animation:

https://main--express-website--adobe.hlx3.page/express/

vs.

https://hero-animation-block--express-website--adobe.hlx3.page/express/