### PR TITLE
fix(missing-variable): undo accidental removal of color-info-accent-light var

### DIFF
--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -17,6 +17,7 @@
   --color-info-accent-down: #3D3DB4;
   --color-info-accent-reverse: #eeeefc;
   --color-info-accent-reverse-down: #e6e6f4;
+  --color-info-accent-light: #DEDEF9;
   --color-info-primary: #242424;
   --color-info-primary-hover: #090909;
   --color-info-primary-down: #000;


### PR DESCRIPTION
Fix accidental removal of the variable: `  --color-info-accent-light: #DEDEF9;`