### PR TITLE
fix(template-list): wrong link color

### DIFF
--- a/express/blocks/template-list/template-list.css
+++ b/express/blocks/template-list/template-list.css
@@ -48,7 +48,6 @@ main .template-list .template-title p {
 main .template-list .template-link,
 main .template-list .template-title-link {
   text-decoration: none;
-  color: #1473E6;
   padding-left: 16px;
   padding-top: 6px;
   display: flex;


### PR DESCRIPTION
Fix https://github.com/adobe/express-website-issues/issues/225

- Before: https://main--express-website--adobe.hlx3.page/express/
- After: https://issue-225--express-website--adobe.hlx3.page/express/