### PR TITLE
Pricing block visual bugs

### DIFF
--- a/express/blocks/pricing-columns/pricing-columns.js
+++ b/express/blocks/pricing-columns/pricing-columns.js
@@ -159,7 +159,7 @@ function decoratePlan($column) {
     if ($element.classList.contains('button-container')) {
       const $link = $element.querySelector('a');
       plans.push({
-        name: $link.innerText,
+        name: $link.textContent,
         url: $link.href,
       });
     }
@@ -195,7 +195,7 @@ function decoratePlan($column) {
     $pricingHeader.append($pricingPlan);
 
     const $pricingCta = createTag('a', { class: 'pricing-columns-cta button large' });
-    $pricingCta.innerText = $elements[2].innerText;
+    $pricingCta.innerHTML = $elements[2].textContent;
     $pricingCta.href = plans[0].url;
     $pricingHeader.append($pricingCta);
 


### PR DESCRIPTION
This is a fix pull requested related to issue https://github.com/adobe/express-website-issues/issues/249.

The title bug was fixed by changing the first paragraph in the related pages to H3.
The pricing bug was fixed by removing the e|E filter from the match expression
The icon bug was fixed by adjusting the authored document to contain the right icon name
The pricing button bug was fixed by only bringing over the textContent rather than the whole a element