### PR TITLE
fix(banner): remove top padding from first banner section

### DIFF
--- a/express/blocks/banner/banner.css
+++ b/express/blocks/banner/banner.css
@@ -7,6 +7,10 @@ main .section-wrapper.banner-light-container {
   padding: 120px 15px;
 }
 
+main .section-wrapper:first-of-type {
+  padding-top: 0;
+}
+
 main .section-wrapper.banner-container > div {
   padding: 0;
 }


### PR DESCRIPTION
The banner (light) block adds a top padding of 120px, which is fine when used in the middle of a page, but feels awkward when used at the top.

Before: https://main--express-website--adobe.hlx3.page/express/pricing
After: https://banner-issue--express-website--adobe.hlx3.page/express/pricing