### PR TITLE
fix(columns): brand icon not visible in firefox

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -162,7 +162,8 @@ main .fixed-button.button-container {
 body.no-brand-header main .columns:first-of-type .brand.icon {
   display: unset;
   height: 32px;
-  width: max-content;
+  width: auto;
+  margin: 0 auto;
   position: absolute;
   top: 40px;
   left: 50%;


### PR DESCRIPTION
Firefox not showing brand icon on pricing page:
- Before: https://main--express-website--adobe.hlx3.page/express/pricing
- After: https://ff-bug--express-website--adobe.hlx3.page/express/pricing