### PR TITLE
fix(issue-252): prevent layouts from scrolling if the javascript bugs out

### DIFF
--- a/express/blocks/layouts/layouts.css
+++ b/express/blocks/layouts/layouts.css
@@ -3,6 +3,7 @@ main .layouts {
   display: flex;
   width: 100%;
   justify-content: center;
+  flex-wrap: wrap;
 }
 
 main .layouts .masonry-col {


### PR DESCRIPTION
Fix for issue 252: Prevents horizontal scrolling on every breakpoint if the JavaScript is not working properly. 

This **does not impact the current layout** in any breakpoint, including desktop. It is a safeguard for 'just in case' the layout is not rendering correctly.

- Fix https://github.com/adobe/express-website-issues/issues/252