### PR TITLE
fix(columns): flag 1st columns block as marquee

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -92,7 +92,7 @@ main .columns h6 {
   margin-top: 32px;
 }
 
-main .columns:first-of-type {
+main .columns.columns-marquee {
   visibility: unset;
   min-height: unset;
 }
@@ -161,7 +161,7 @@ main .columns .icon {
   height: 22px;
 }
 
-main .columns:first-of-type .brand.icon {
+main .columns.columns-marquee .brand.icon {
   display: none;
 }
 
@@ -169,7 +169,7 @@ main .fixed-button.button-container {
   display: none;
 }
 
-body.no-brand-header main .columns:first-of-type .brand.icon {
+body.no-brand-header main .columns.columns-marquee .brand.icon {
   display: unset;
   height: 32px;
   width: auto;
@@ -314,7 +314,7 @@ main .columns-highlight-container .column p {
 
 
 @media (min-width: 900px) {
-  body.no-brand-header main .columns:first-of-type .brand.icon {
+  body.no-brand-header main .columns.columns-marquee .brand.icon {
     position: unset;
     top: unset;
     left: unset;
@@ -431,7 +431,7 @@ main .columns .column:nth-child(2):not(.column-picture) {
   padding-left: 16px;
 }
 
-body.no-brand-header main .columns:first-of-type:not(.center) .brand.icon {
+body.no-brand-header main .columns.columns-marquee:not(.center) .brand.icon {
   padding-left: 0;
 }
 
@@ -516,7 +516,7 @@ body.no-brand-header main .columns:first-of-type:not(.center) .brand.icon {
     padding-left: 16px;
   }
 
-  body.no-brand-header main .columns:first-of-type:not(.center) .brand.icon {
+  body.no-brand-header main .columns.columns-marquee:not(.center) .brand.icon {
     transform: none;
     left: 0;
     padding-left: 32px;

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -580,6 +580,14 @@ export function decorateBlocks($main) {
   });
 }
 
+function decorateMarqueeColumns($main) {
+  // flag first columns block in first section block as marquee
+  const $firstColumnsBlock = $main.querySelector('.section-wrapper:first-of-type .columns:first-of-type');
+  if ($firstColumnsBlock) {
+    $firstColumnsBlock.classList.add('columns-marquee');
+  }
+}
+
 export function loadBlock($block) {
   const blockName = $block.getAttribute('data-block-name');
   import(`/express/blocks/${blockName}/${blockName}.js`)
@@ -1327,6 +1335,7 @@ export function decorateMain($main) {
   wrapSections($main.querySelectorAll(':scope > div'));
   decorateButtons($main);
   decorateBlocks($main);
+  decorateMarqueeColumns($main);
   fixIcons($main);
   checkWebpFeature(() => {
     webpPolyfill($main);

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -340,7 +340,7 @@ main .section-wrapper:last-of-type {
   margin-bottom: 0;
 }
 
-main .columns:first-of-type {
+main .columns.columns-marquee {
   visibility: hidden;
   min-height: 1024px;
 }


### PR DESCRIPTION
Fix https://github.com/adobe/express-website-issues/issues/271

The columns block has a brand icon treatment that should only be applied to an icon in the first columns block on a page (typically the "marquee"). The current logic of identifying the first columns block on a page is flawed: it is using the `:first-of-type` pseudo selector which is only effective within the same parent element. I changed it to a JS-based solution now adding a `columns-marquee` class to the first columns block in the first section.

This change affects a wide range of pages because it affects the columns block. I aded a few test pages to make sure it causes no more regressions.

The bug was detected on this page, where the 2nd to last block doesn't display the education icon (because it it wrongfully treated as a brand icon):
- Before: https://main--express-website--adobe.hlx3.page/education/express/
- After: https://issue-271--express-website--adobe.hlx3.page/education/express/