### PR TITLE
feat(price): use page language for currency formatting

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -428,7 +428,8 @@ function getCurrencyDisplay(currency) {
 }
 
 export function formatPrice(price, currency, currencyDisplay) {
-  return new Intl.NumberFormat(navigator.language, {
+  const locale = getLanguage(getLocale(window.location));
+  return new Intl.NumberFormat(locale, {
     style: 'currency',
     currency,
     currencyDisplay,


### PR DESCRIPTION
Use page language to format the currency symbol instead of the browser language.

Before: https://main--express-website--adobe.hlx3.page/jp/express/pricing
After: https://currency-lang--express-website--adobe.hlx3.page/jp/express/pricing