### PR TITLE
fix: price formatting for DKK, NOK, SEK and TWD

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -424,11 +424,14 @@ function getCurrencyDisplay(currency) {
   if (currency === 'JPY') {
     return 'name';
   }
+  if (['SEK', 'DKK', 'NOK'].includes(currency)) {
+    return 'code';
+  }
   return 'symbol';
 }
 
 export function formatPrice(price, currency, currencyDisplay) {
-  const locale = getLanguage(getLocale(window.location));
+  const locale = getLanguage(currency === 'TWD' ? 'us' : getLocale(window.location));
   return new Intl.NumberFormat(locale, {
     style: 'currency',
     currency,


### PR DESCRIPTION
Fix https://github.com/adobe/express-website-issues/issues/275

Test:
- https://issue-275--express-website--adobe.hlx3.page/dk/express/pricing?country=dk
- https://issue-275--express-website--adobe.hlx3.page/no/express/pricing?country=no
- https://issue-275--express-website--adobe.hlx3.page/se/express/pricing?country=se
- https://issue-275--express-website--adobe.hlx3.page/tw/express/pricing?country=tw