### PR TITLE
chore: add close marker to region picker

### DIFF
--- a/express/scripts/delayed.js
+++ b/express/scripts/delayed.js
@@ -74,7 +74,6 @@ async function showRegionPicker() {
       const destLocale = pathSplits[1] ? `${pathSplits[1]}` : 'us';
       const off = locale !== 'us' ? locale.length + 1 : 0;
       const gPath = window.location.pathname.substr(off);
-
       let domain = '';
       if (window.location.hostname.endsWith('.adobe.com')) domain = ' domain=adobe.com;';
       const cookieValue = `international=${destLocale};${domain} path=/`;
@@ -85,6 +84,12 @@ async function showRegionPicker() {
       window.location.href = prefix + gPath;
     });
   });
+  // focus link of current region
+  const lang = getLanguage(getLocale(new URL(window.location.href))).toLowerCase();
+  const currentRegion = $regionPicker.querySelector(`li a[lang="${lang}"]`);
+  if (currentRegion) {
+    currentRegion.focus();
+  }
 }
 
 const locale = getLocale(window.location);

--- a/express/styles/lazy-styles.css
+++ b/express/styles/lazy-styles.css
@@ -226,7 +226,10 @@ main .blog-posts .card .card-body p {
 
 #region-picker nav .language-Navigation_region-List li a:hover {
   text-decoration: underline;
-  outline-width: 0;
+}
+
+#region-picker nav .language-Navigation_region-List li a:focus {
+  outline: auto;    
 }
 
 #region-picker .close {
@@ -240,6 +243,7 @@ main .blog-posts .card .card-body p {
   position: absolute;
   background-color: #444;
   pointer-events: none;
+  cursor: pointer;
 }
 
 #region-picker .close::after,


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/DOTCOM-54320

this one is a little bit hard to test because of CORS outside of www.adobe.com and www.stage.adobe.com 

<img width="1118" alt="Screen Shot 2021-11-29 at 5 10 07 PM" src="https://user-images.githubusercontent.com/5289336/143962280-b1c680bd-298d-4eac-aef8-79f92c27f724.png">

the code seems relatively benign.. 
https://region-picker-close--express-website--adobe.hlx3.page/express/?lighthouse=on

if someone wants to test this locally: checkout the branch, start up chrome without websecurity...

```
/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome -disable-web-security --user-data-dir=/tmp/chrome-temp
```

