### PR TITLE
chore: make sure sixcols is always displayed as masonry

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -411,7 +411,7 @@ export async function decorateTemplateList($block) {
   if ($block.classList.contains('horizontal')) {
     /* carousel */
     buildCarousel(':scope > .template', $block, '');
-  } else if (rows > 6) {
+  } else if (rows > 6 || $block.classList.contains('sixcols')) {
     /* flex masonry */
     // console.log(`masonry-rows: ${rows}`);
     const cells = Array.from($block.children);


### PR DESCRIPTION
https://sixcols-always-masonry--express-website--adobe.hlx.live/jp/express/create/advertisement

vs. 

https://main--express-website--adobe.hlx.live/jp/express/create/advertisement

check on mobile breakpoint as well...
