### PR TITLE
fix(pricing-columns): do not let price wrap

### DIFF
--- a/express/blocks/pricing-columns/pricing-columns.css
+++ b/express/blocks/pricing-columns/pricing-columns.css
@@ -53,6 +53,7 @@ main .pricing-columns-plan {
 
 main .pricing-columns-price {
     display: flex;
+    flex-wrap: nowrap;
     font-size: var(--heading-font-size-l);
     font-weight: var(--heading-font-weight);
 }
@@ -176,6 +177,7 @@ main .pricing-columns-content .pricing-iconlist .pricing-iconlist .pricing-iconl
     main .pricing-columns-plan {
         display: flex;
         flex-direction: row;
+        flex-wrap: nowrap;
         align-items: center;
     }
 


### PR DESCRIPTION
Some price/currency combos can result in ugly wrapping, e.g.

Before: https://main--express-website--adobe.hlx3.page/no/express/pricing?country=no (switch to annual plan)
After: https://price-nowrap--express-website--adobe.hlx3.page/no/express/pricing?country=no