### PR TITLE
fix: make videos relative

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -448,6 +448,10 @@ export async function decorateTemplateList($block) {
       if (!$imgLink.href.includes('.mp4')) {
         linkImage($parent);
       } else {
+        let videoLink = $imgLink.href;
+        if (videoLink.includes('/media_')) {
+          videoLink = `./media_${videoLink.split('/media_')[1]}`;
+        }
         $tmplt.querySelectorAll(':scope br').forEach(($br) => $br.remove());
         const $picture = $tmplt.querySelector('picture');
         if ($picture) {
@@ -461,7 +465,7 @@ export async function decorateTemplateList($block) {
             title: $img.getAttribute('alt'),
           });
           $video.append(createTag('source', {
-            src: $imgLink.href,
+            src: videoLink,
             type: 'video/mp4',
           }));
           $parent.replaceChild($video, $picture);


### PR DESCRIPTION
some of the newly added videos on are pointing to URLs outside of the /express/ space which makes them not load.
easiest way to see, is to compare the network tab filtered by `mp4` and check the `media_` URLs

https://relative-videos--express-website--adobe.hlx.live/express/create
vs.
https://main--express-website--adobe.hlx.live/express/create

the most noticeable effect is in safari, which has a different eventing on video load where the rest of the templates get cut off.
https://www.stage.adobe.com/express/create