### PR TITLE
fix: branding header

### DIFF
--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -95,7 +95,7 @@ header {
 }
 
 body.no-brand-header header, body.no-desktop-brand-header header {
-  height: 65px;
+  height: 64px;
   background-image: unset;
 }
 


### PR DESCRIPTION
bring back the brand header:

https://branding-header--express-website--adobe.hlx3.page/express/create

vs. 

https://main--express-website--adobe.hlx3.page/express/create