### PR TITLE
chore: sync privacy load

### DIFF
--- a/express/scripts/delayed.js
+++ b/express/scripts/delayed.js
@@ -167,7 +167,7 @@ function loadFEDS() {
         $a.setAttribute('href', hrefURL.toString());
       });
     }
-    setTimeout(loadPrivacy, 3000);
+    setTimeout(loadPrivacy, 0);
   });
   let prefix = '';
   if (!['www.adobe.com', 'www.stage.adobe.com'].includes(window.location.hostname)) {


### PR DESCRIPTION
i am not sure that this is the root cause, but there seems to be a delay for analytics events firing, this may be the cause.

https://sync-privacy-load--express-website--adobe.hlx3.page/express/