### PR TITLE
Remove standalone privacy and rely on FEDS Privacy

### DIFF
--- a/express/scripts/delayed.js
+++ b/express/scripts/delayed.js
@@ -119,6 +119,10 @@ w.fedsConfig = {
       window.location.href = sparkLoginUrl;
     },
   },
+  privacy: {
+    otDomainId: '7a5eb705-95ed-4cc4-a11d-0cc5760e93db',
+    footerLinkSelector: '#openCookieModal',
+  },
 };
 
 function loadIMS() {
@@ -128,14 +132,6 @@ function loadIMS() {
     locale,
   };
   loadScript('https://auth.services.adobe.com/imslib/imslib.min.js');
-}
-
-function loadPrivacy() {
-  window.fedsConfig.privacy = {
-    otDomainId: '7a5eb705-95ed-4cc4-a11d-0cc5760e93db',
-    footerLinkSelector: '#openCookieModal',
-  };
-  loadScript('https://www.adobe.com/etc/beagle/public/globalnav/adobe-privacy/latest/privacy.min.js');
 }
 
 function loadFEDS() {
@@ -168,7 +164,6 @@ function loadFEDS() {
         $a.setAttribute('href', hrefURL.toString());
       });
     }
-    setTimeout(loadPrivacy, 0);
   });
   let prefix = '';
   if (!['www.adobe.com', 'www.stage.adobe.com'].includes(window.location.hostname)) {


### PR DESCRIPTION
## Description
Rely on FEDS Privacy component and avoid double loading.

https://remove-standalone-privacy--express-website--adobe.hlx3.page/express/

## Motivation and Context
Privacy was loaded as standalone to introduce some delay and improve LH scores. However, analytics team found some issues and the delay was removed, making the Privacy component load twice. 

## How Has This Been Tested?
locally

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
