### PR TITLE
fix(columns): gray gradient on ios

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -545,7 +545,7 @@ body.no-brand-header main .columns.columns-marquee:not(.center) .brand.icon {
     width: 100%;
     padding-bottom: 20px;
     z-index: 2;
-    background: linear-gradient(180deg, var(--color-white) 0%, var(--color-white) 100%);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
     transform: translateY(101%);
     transition: transform 1s;
     pointer-events: none;


### PR DESCRIPTION
Part of https://github.com/adobe/express-website-issues/issues/299

The gradient behind the floating CTA button is smoke colored on iOS:
![image](https://user-images.githubusercontent.com/1609742/145843984-1eb0568e-ac05-46ef-8ecf-046af33a15b6.png)

Before: https://main--express-website--adobe.hlx3.page/express/create/flyer
After: https://issue-299--express-website--adobe.hlx3.page/express/create/flyer