### PR TITLE
fix(columns): missing promotion button

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -557,7 +557,7 @@ body.no-brand-header main .columns.columns-marquee:not(.center) .brand.icon {
     bottom: 0;
   }
 
-  body.has-fixed-button .button-container a.primary {
+  body.has-fixed-button .button-container a.primary.accent {
     display: none;
   }
 


### PR DESCRIPTION
Fix https://github.com/adobe/express-website-issues/issues/300

We are hiding buttons too eagerly - I think we should only hide `accent` buttons

Before: https://main--express-website--adobe.hlx3.page/express/create/flyer
After: https://issue-300--express-website--adobe.hlx3.page/express/create/flyer

