### PR TITLE
feat(columns): float button based on body class

### DIFF
--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -161,7 +161,7 @@ export default function decorate($block) {
             entries.forEach((entry) => {
               if (entry.intersectionRatio > 0) {
                 $floatButton.classList.remove('shown');
-              } else {
+              } else if (document.body.classList.contains('has-fixed-button')) {
                 $floatButton.classList.add('shown');
               }
             });


### PR DESCRIPTION
Relates to https://github.com/adobe/express-website-issues/issues/306

This will allow turning off the floating button (mobile viewport) using the `has-fixed-button` class on the body.

Before: https://main--express-website--adobe.hlx3.page/express/create/logo
After: https://float-button-trigger--express-website--adobe.hlx3.page/express/create/logo?lighthouse=on
