### PR TITLE
fix(pricing): respect region when formatting price

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -288,9 +288,10 @@ function getCookie(cname) {
 }
 
 function getCountry() {
-  let country = new URLSearchParams(window.location.search).get('country')
+  let country = new URLSearchParams(window.location.search).get('country');
   if (!country) {
     country = getCookie('international');
+  }
   if (!country) {
     country = getLocale(window.location);
   }

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -288,7 +288,9 @@ function getCookie(cname) {
 }
 
 function getCountry() {
-  let country = getCookie('international');
+  let country = new URLSearchParams(window.location.search).get('country')
+  if (!country) {
+    country = getCookie('international');
   if (!country) {
     country = getLocale(window.location);
   }

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -435,7 +435,7 @@ function getCurrencyDisplay(currency) {
 export function formatPrice(price, currency) {
   const locale = ['USD', 'TWD'].includes(currency)
     ? 'en-GB' // use en-GB for intl $ symbol formatting
-    : getLanguage(getLocale(window.location));
+    : getCountry();
   const currencyDisplay = getCurrencyDisplay(currency);
   return new Intl.NumberFormat(locale, {
     style: 'currency',


### PR DESCRIPTION
Fix https://github.com/adobe/express-website-issues/issues/308

Test: 
1. go to https://issue-308--express-website--adobe.hlx3.page/fr/express/pricing
2. correct price formatting with comma
3. go to https://issue-308--express-website--adobe.hlx3.page/kr/express/pricing?country=fr
4. correct price formatting with comma