### PR TITLE
fix: placeholders

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -195,7 +195,7 @@ export function getIconElement(icons, size, placeholders = window.placeholders) 
     if (placeholders[icon]) {
       alt = placeholders[icon];
     }
-  })
+  });
   $div.innerHTML = getIcon(icons, alt, size);
   return ($div.firstChild);
 }
@@ -1035,7 +1035,8 @@ export async function fixIcons(block = document) {
           // console.log(blockName);
           if (smallIconBlocks.includes(blockName)) size = 22;
         }
-        $picture.parentElement.replaceChild(getIconElement([icon, mobileIcon], size, placeholders), $picture);
+        $picture.parentElement
+          .replaceChild(getIconElement([icon, mobileIcon], size, placeholders), $picture);
       }
     }
   });


### PR DESCRIPTION
## Description

* fetch localized `placeholders.json`
* use localized placeholders as `alt` text for `img`s, `title` text for `svg`s

## Related Issue

- Icon alt texts 287
- Introduce placeholders 307

## Links

- https://placeholders--express-website--adobe.hlx3.page/express/
- https://placeholders--express-website--adobe.hlx3.page/express/pricing
- https://placeholders--express-website--adobe.hlx3.page/dk/express/pricing
- https://placeholders--express-website--adobe.hlx3.page/tw/express/pricing
