### PR TITLE
feat(quick-action-cards): quick action cards block added

### DIFF
--- a/express/blocks/quick-action-cards/quick-action-cards.css
+++ b/express/blocks/quick-action-cards/quick-action-cards.css
@@ -78,11 +78,17 @@ main .quick-action-cards--buttons .quick-action-card--close {
   display: none;
 }
 
-main svg.action-card-chevron {
+main .quick-action-card--open svg, 
+main .quick-action-card--close svg {
   transform: translateY(1px);
+  float: unset;
+  width: 10px;
+  height: 10px;
+  margin: 0;
+  margin-left: 6px;
 }
 
-main .quick-action-card--close svg.action-card-chevron {
+main .quick-action-card--close svg {
   transform: translateY(1px) rotate(180deg);
 }
 
@@ -91,7 +97,7 @@ main .quick-action-cards.quick-action-cards--expanded .quick-action-card {
 }
 
 main .quick-action-cards.quick-action-cards--expanded ~ .quick-action-cards--buttons .quick-action-card--close {
-  display: block;
+  display: inline-block;
 }
 
 main .quick-action-cards.quick-action-cards--expanded ~ .quick-action-cards--buttons .quick-action-card--open {
@@ -107,23 +113,7 @@ main .section-wrapper.quick-action-cards-container > div > p.quick-action-cards-
 
 main .quick-action-card--open, 
 main .quick-action-card--close {
-  display: block;
-  text-decoration: none;
-  border-radius: 18px;
-  padding: 8px 1.2em 8px 1.2em;
-  text-align: center;
-  font-size: var(--body-font-size-s);
-  font-style: normal;
-  font-weight: 600;
-  line-height: var(--body-line-height);
-  cursor: pointer;
-  transition: background-color .3s, color .3s, border .3s;
-  border-width: 0;
-  border-style: solid;
   margin: 10px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   margin-left: auto;
   margin-right: auto;
   background-color: var(--color-info-secondary);

--- a/express/blocks/quick-action-cards/quick-action-cards.css
+++ b/express/blocks/quick-action-cards/quick-action-cards.css
@@ -116,17 +116,6 @@ main .quick-action-card--close {
   margin: 10px;
   margin-left: auto;
   margin-right: auto;
-  background-color: var(--color-info-secondary);
-}
-
-main .quick-action-card--open:hover , 
-main .quick-action-card--close:hover {
-  background-color: var(--color-info-secondary-hover);
-}
-
-main .quick-action-card--open:active , 
-main .quick-action-card--close:active {
-  background-color: var(--color-info-secondary-down);
 }
 
 @media screen and (min-width: 900px) {

--- a/express/blocks/quick-action-cards/quick-action-cards.css
+++ b/express/blocks/quick-action-cards/quick-action-cards.css
@@ -126,9 +126,18 @@ main .quick-action-card--close {
   text-overflow: ellipsis;
   margin-left: auto;
   margin-right: auto;
-  background-color: var(--color-gray-200);
-} 
+  background-color: var(--color-info-secondary);
+}
 
+main .quick-action-card--open:hover , 
+main .quick-action-card--close:hover {
+  background-color: var(--color-info-secondary-hover);
+}
+
+main .quick-action-card--open:active , 
+main .quick-action-card--close:active {
+  background-color: var(--color-info-secondary-down);
+}
 
 @media screen and (min-width: 900px) {
   main .section-wrapper.quick-action-cards-container > div {

--- a/express/blocks/quick-action-cards/quick-action-cards.css
+++ b/express/blocks/quick-action-cards/quick-action-cards.css
@@ -1,0 +1,146 @@
+
+main .section-wrapper.quick-action-cards-container {
+  padding: 0;
+  text-align: left;
+}
+
+main .section-wrapper.quick-action-cards-container > div {
+  text-align: left;
+  margin: 0 auto;
+  max-width: 400px;
+  padding: 80px 32px;
+  box-sizing: content-box;
+}
+
+main .section-wrapper.quick-action-cards-container > div > h1,
+main .section-wrapper.quick-action-cards-container > div > h2,
+main .section-wrapper.quick-action-cards-container > div > h3,
+main .section-wrapper.quick-action-cards-container > div > h4,
+main .section-wrapper.quick-action-cards-container > div > h5,
+main .section-wrapper.quick-action-cards-container > div > h6,
+main .section-wrapper.quick-action-cards-container > div > p {
+  margin-bottom: 16px;
+  text-align: left;
+}
+
+main .quick-action-cards h1,
+main .quick-action-cards h2,
+main .quick-action-cards h3,
+main .quick-action-cards h4,
+main .quick-action-cards h5,
+main .quick-action-cards h6,
+main .quick-action-cards p {
+  color: var(--body-color);
+}
+
+main .quick-action-cards p.button-container {
+  text-align: left;
+  display: flex;
+  gap: 16px;
+}
+
+main .quick-action-cards p.button-container a {
+  margin: 0;
+}
+
+main .section-wrapper.quick-action-cards-container > div > p {
+  margin-top: 16px;
+  margin-bottom: 32px;
+}
+
+main .section-wrapper.quick-action-cards-container > div > :first-child {
+  margin-top: 0;
+}
+
+main .quick-action-cards {
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px 10px;
+}
+
+main .quick-action-cards .quick-action-card {
+  border-radius: 17px;
+  overflow: hidden;
+  border: 2px solid var(--color-gray-200);
+  text-align: left;
+}
+
+main .quick-action-cards .quick-action-card > div:not(.quick-action-card-image) {
+  padding: 20px;
+}
+
+main .quick-action-cards:not(.quick-action-cards--expanded) .quick-action-card:not(:first-child):not(:nth-child(2)):not(:nth-child(3)) {
+  display: none;
+}
+
+main .quick-action-cards--buttons .quick-action-card--close {
+  display: none;
+}
+
+main svg.action-card-chevron {
+  transform: translateY(1px);
+}
+
+main .quick-action-card--close svg.action-card-chevron {
+  transform: translateY(1px) rotate(180deg);
+}
+
+main .quick-action-cards.quick-action-cards--expanded .quick-action-card {
+  display: block;
+}
+
+main .quick-action-cards.quick-action-cards--expanded ~ .quick-action-cards--buttons .quick-action-card--close {
+  display: block;
+}
+
+main .quick-action-cards.quick-action-cards--expanded ~ .quick-action-cards--buttons .quick-action-card--open {
+  display: none;
+} 
+
+main .section-wrapper.quick-action-cards-container > div > p.quick-action-cards--buttons {
+  margin: 0;
+  margin-top: 32px;
+  text-align: center;
+  display: block;
+}
+
+main .quick-action-card--open, 
+main .quick-action-card--close {
+  display: block;
+  text-decoration: none;
+  border-radius: 18px;
+  padding: 8px 1.2em 8px 1.2em;
+  text-align: center;
+  font-size: var(--body-font-size-s);
+  font-style: normal;
+  font-weight: 600;
+  line-height: var(--body-line-height);
+  cursor: pointer;
+  transition: background-color .3s, color .3s, border .3s;
+  border-width: 0;
+  border-style: solid;
+  margin: 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-left: auto;
+  margin-right: auto;
+  background-color: var(--color-gray-200);
+} 
+
+
+@media screen and (min-width: 900px) {
+  main .section-wrapper.quick-action-cards-container > div {
+    max-width: 1024px;
+  }
+
+  main .quick-action-cards {
+    gap: 32px 17px;
+  }
+
+  main .quick-action-cards .quick-action-card {
+    max-width: 31%;
+    max-width: calc(33% - 14px);
+  }
+}

--- a/express/blocks/quick-action-cards/quick-action-cards.js
+++ b/express/blocks/quick-action-cards/quick-action-cards.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// eslint-disable-next-line import/no-unresolved
+import { createTag } from '../../scripts/scripts.js';
+
+export default function decorate($block) {
+  const $cards = Array.from($block.querySelectorAll(':scope>div'));
+  $cards.forEach(($card) => {
+    $card.classList.add('quick-action-card');
+    const $cardDivs = [...$card.children];
+    $cardDivs.forEach(($div) => {
+      if ($div.querySelector('img')) {
+        $div.classList.add('quick-action-card-image');
+      }
+      const $a = $div.querySelector('a');
+      if ($a && $a.textContent.startsWith('https://')) {
+        const $wrapper = createTag('a', { href: $a.href, class: 'quick-action-card' });
+        $a.remove();
+        $wrapper.innerHTML = $card.innerHTML;
+        $block.replaceChild($wrapper, $card);
+      }
+    });
+  });
+  if ($cards.length > 3) {
+    const $seeMore = document.createElement('button');
+    $seeMore.classList.add('quick-action-card--open');
+    $seeMore.insertAdjacentHTML('beforeend', 'See more <svg class="action-card-chevron" xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="currentColor" viewBox="0 0 1200 1200"><path d="M600.006 989.352l178.709-178.709L1200 389.357l-178.732-178.709L600.006 631.91L178.721 210.648L0 389.369l421.262 421.262l178.721 178.721h.023z" fill="currentColor"></path></svg>');
+    $seeMore.addEventListener('click', () => {
+      $block.classList.add('quick-action-cards--expanded');
+    });
+    const $seeLess = document.createElement('button');
+    $seeLess.classList.add('quick-action-card--close');
+    $seeLess.insertAdjacentHTML('beforeend', 'See less <svg class="action-card-chevron" xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="currentColor" viewBox="0 0 1200 1200"><path d="M600.006 989.352l178.709-178.709L1200 389.357l-178.732-178.709L600.006 631.91L178.721 210.648L0 389.369l421.262 421.262l178.721 178.721h.023z" fill="currentColor"></path></svg>');
+    $seeLess.addEventListener('click', () => {
+      $block.classList.remove('quick-action-cards--expanded');
+    });
+    const $pButton = document.createElement('p');
+    if ($block.nextSibling) {
+      $block.parentNode.insertBefore($pButton, $block.nextSibling);
+    } else {
+      $block.parentNode.appendChild($pButton);
+    }
+    $pButton.classList.add('quick-action-cards--buttons')
+    $pButton.appendChild($seeMore);
+    $pButton.appendChild($seeLess);
+  }
+}

--- a/express/blocks/quick-action-cards/quick-action-cards.js
+++ b/express/blocks/quick-action-cards/quick-action-cards.js
@@ -42,6 +42,7 @@ export default function decorate($block) {
     $seeMore.classList.add('secondary');
     $seeMore.innerText = 'See more';
     $seeMore.insertAdjacentHTML('beforeend', chevron);
+    // eslint-disable-next-line no-script-url
     $seeMore.setAttribute('href', 'javascript: void(0)');
     $seeMore.addEventListener('click', () => {
       $block.classList.add('quick-action-cards--expanded');
@@ -52,6 +53,7 @@ export default function decorate($block) {
     $seeLess.classList.add('secondary');
     $seeLess.innerText = 'See less';
     $seeLess.insertAdjacentHTML('beforeend', chevron);
+    // eslint-disable-next-line no-script-url
     $seeLess.setAttribute('href', 'javascript: void(0)');
     $seeLess.addEventListener('click', () => {
       $block.classList.remove('quick-action-cards--expanded');

--- a/express/blocks/quick-action-cards/quick-action-cards.js
+++ b/express/blocks/quick-action-cards/quick-action-cards.js
@@ -10,8 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
+import {
+  createTag,
+  getIcon,
 // eslint-disable-next-line import/no-unresolved
-import { createTag } from '../../scripts/scripts.js';
+} from '../../scripts/scripts.js';
 
 export default function decorate($block) {
   const $cards = Array.from($block.querySelectorAll(':scope>div'));
@@ -32,15 +35,24 @@ export default function decorate($block) {
     });
   });
   if ($cards.length > 3) {
-    const $seeMore = document.createElement('button');
+    const chevron = getIcon('chevron');
+    const $seeMore = document.createElement('a');
     $seeMore.classList.add('quick-action-card--open');
-    $seeMore.insertAdjacentHTML('beforeend', 'See more <svg class="action-card-chevron" xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="currentColor" viewBox="0 0 1200 1200"><path d="M600.006 989.352l178.709-178.709L1200 389.357l-178.732-178.709L600.006 631.91L178.721 210.648L0 389.369l421.262 421.262l178.721 178.721h.023z" fill="currentColor"></path></svg>');
+    $seeMore.classList.add('button');
+    $seeMore.classList.add('secondary');
+    $seeMore.innerText = 'See more';
+    $seeMore.insertAdjacentHTML('beforeend', chevron);
+    $seeMore.setAttribute('href', 'javascript: void(0)');
     $seeMore.addEventListener('click', () => {
       $block.classList.add('quick-action-cards--expanded');
     });
-    const $seeLess = document.createElement('button');
+    const $seeLess = document.createElement('a');
     $seeLess.classList.add('quick-action-card--close');
-    $seeLess.insertAdjacentHTML('beforeend', 'See less <svg class="action-card-chevron" xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="currentColor" viewBox="0 0 1200 1200"><path d="M600.006 989.352l178.709-178.709L1200 389.357l-178.732-178.709L600.006 631.91L178.721 210.648L0 389.369l421.262 421.262l178.721 178.721h.023z" fill="currentColor"></path></svg>');
+    $seeLess.classList.add('button');
+    $seeLess.classList.add('secondary');
+    $seeLess.innerText = 'See less';
+    $seeLess.insertAdjacentHTML('beforeend', chevron);
+    $seeLess.setAttribute('href', 'javascript: void(0)');
     $seeLess.addEventListener('click', () => {
       $block.classList.remove('quick-action-cards--expanded');
     });

--- a/express/blocks/quick-action-cards/quick-action-cards.js
+++ b/express/blocks/quick-action-cards/quick-action-cards.js
@@ -13,6 +13,7 @@
 import {
   createTag,
   getIcon,
+  fetchPlaceholders,
 // eslint-disable-next-line import/no-unresolved
 } from '../../scripts/scripts.js';
 
@@ -40,19 +41,21 @@ export default function decorate($block) {
     $seeMore.classList.add('quick-action-card--open');
     $seeMore.classList.add('button');
     $seeMore.classList.add('secondary');
-    $seeMore.innerText = 'See more';
-    $seeMore.insertAdjacentHTML('beforeend', chevron);
+    const $seeLess = document.createElement('a');
+    $seeLess.classList.add('quick-action-card--close');
+    $seeLess.classList.add('button');
+    $seeLess.classList.add('secondary');
+    fetchPlaceholders().then((placeholders) => {
+      $seeMore.innerText = placeholders['see-more'];
+      $seeLess.innerText = placeholders['see-less'];
+      $seeMore.insertAdjacentHTML('beforeend', chevron);
+      $seeLess.insertAdjacentHTML('beforeend', chevron);
+    });
     // eslint-disable-next-line no-script-url
     $seeMore.setAttribute('href', 'javascript: void(0)');
     $seeMore.addEventListener('click', () => {
       $block.classList.add('quick-action-cards--expanded');
     });
-    const $seeLess = document.createElement('a');
-    $seeLess.classList.add('quick-action-card--close');
-    $seeLess.classList.add('button');
-    $seeLess.classList.add('secondary');
-    $seeLess.innerText = 'See less';
-    $seeLess.insertAdjacentHTML('beforeend', chevron);
     // eslint-disable-next-line no-script-url
     $seeLess.setAttribute('href', 'javascript: void(0)');
     $seeLess.addEventListener('click', () => {

--- a/express/blocks/quick-action-cards/quick-action-cards.js
+++ b/express/blocks/quick-action-cards/quick-action-cards.js
@@ -50,7 +50,7 @@ export default function decorate($block) {
     } else {
       $block.parentNode.appendChild($pButton);
     }
-    $pButton.classList.add('quick-action-cards--buttons')
+    $pButton.classList.add('quick-action-cards--buttons');
     $pButton.appendChild($seeMore);
     $pButton.appendChild($seeLess);
   }


### PR DESCRIPTION
Added the action cards block

Fix https://github.com/adobe/express-website-issues/issues/214

- Draft page for testing  the block: `/drafts/rofe/feature/quick-actions`

- The '_See more_' button will appear if there are more than 3 action cards listed.

- The button is reads "_See more_" and "_See less_" using [placeholders](https://github.com/adobe/express-website/pull/305) 

- The Desktop version is following the XD specs: https://xd.adobe.com/view/858f0156-6fe3-441a-8e53-a39cc8be79fc-d0dc/screen/fa5483b0-3d01-4c69-a5b4-2068f5f78f3d/

![image](https://user-images.githubusercontent.com/62023521/149592742-38b0ecc7-eaec-4000-bd5e-d46a2194858d.png)
![image](https://user-images.githubusercontent.com/62023521/149592705-82dad771-2d2b-403c-9cd4-9bbd52955d64.png)

- The Mobile version also lists 3 cards and then show the _'See more'_ button:
![image](https://user-images.githubusercontent.com/62023521/149593461-cf8ac951-4506-4e27-a51b-ab3473964d17.png)
