### PR TITLE
Columns Highlight: Video implementation

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -345,11 +345,7 @@ main .columns.highlight.width-2-columns .column-picture {
   order: -1
 }
 
-main .column-video {
-  display: block;
-}
-
-main .columns.highlight .column-video picture:hover {
+main .columns-video {
   cursor: pointer;
 }
 

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -88,20 +88,20 @@ main .columns h1.columns-heading-very-long {
 
 main .columns h1.columns-heading-x-long {
   font-size: var(--heading-font-size-m);
-}  
+}
 
 
 @media (min-width: 1200px) {
   main .columns h1.columns-heading-long {
     font-size: var(--heading-font-size-xxl);
-  }  
+  }
   main .columns h1.columns-heading-very-long {
     font-size: var(--heading-font-size-xl);
-  }  
+  }
 
   main .columns h1.columns-heading-x-long {
     font-size: var(--heading-font-size-l);
-  }  
+  }
 }
 
 main .columns h2 {
@@ -116,7 +116,7 @@ main .columns h2.columns-heading-very-long {
 @media (min-width: 1200px) {
   main .columns h2.columns-heading-very-long {
     font-size: var(--heading-font-size-xl);
-  }  
+  }
 }
 
 main .columns h3 {
@@ -128,7 +128,7 @@ main .columns h4,
 main .columns h5,
 main .columns h6 {
   font-size: var(--heading-font-size-m);
-  line-height: 1.14; 
+  line-height: 1.14;
   margin-top: 32px;
 }
 
@@ -315,6 +315,14 @@ main .columns.highlight.width-2-columns .column-picture {
   order: -1
 }
 
+main .column-video {
+  display: block;
+}
+
+main .columns.highlight .column-video picture:hover {
+  cursor: pointer;
+}
+
 main .columns.highlight > div {
   padding: 0;
 }
@@ -399,13 +407,13 @@ main .columns.highlight .column p {
     padding-left: 32px;
     padding-right: 32px;
   }
-  
+
   main .columns > div {
     flex-direction: row;
     text-align: left;
     align-items: center;
   }
-  
+
   main .section-wrapper div.columns > div {
     position: relative;
   }
@@ -424,7 +432,7 @@ main .columns.highlight .column p {
     line-height: 29px;
     display: block;
   }
-  
+
 main .columns .column {
   margin: 0;
 }
@@ -596,11 +604,11 @@ main .columns.highlight .column.column-picture {
   main .fixed-button.button-container {
     display: none;
   }
-  
+
   body.has-fixed-button .button-container a.accent {
     display: inline-block;
   }
-    
+
   body.no-brand-header main .columns.columns-marquee:not(.center) .brand.icon {
     padding-left: 0px;
   }
@@ -670,7 +678,7 @@ main .columns.highlight .column.column-picture {
     padding-left: 8px;
     padding-right: 8px;
   }
-  
+
   main .columns .column:nth-child(2):not(.column-picture):not(.hero-animation-overlay) {
     padding-left: 16px;
   }

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -90,6 +90,36 @@ main .columns h1.columns-heading-x-long {
   font-size: var(--heading-font-size-m);
 }
 
+main .video-overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: rgba(0,0,0,0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+main .video-overlay .video-overlay-video {
+  width: 90vw;
+  height: calc(90vw * 9 / 16);
+  max-height: 100vh;
+}
+
+main .video-overlay .video-overlay-video.vimeo {
+  width: 90vh;
+  max-width: 90vw;
+  height: 90vw;
+  max-height: 90vh;
+}
+
+main .video-overlay .video-overlay-video iframe {
+  width: 100%;
+  height: 100%;
+}
 
 @media (min-width: 1200px) {
   main .columns h1.columns-heading-long {

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -38,7 +38,6 @@ function hideVideo(push) {
 }
 
 function displayVideo(url, title, push) {
-  console.log('test');
   const canPlayInline = url.includes('youtu') || url.includes('vimeo');
   if (canPlayInline) {
     const $overlay = createTag('div', { class: 'tutorials-overlay' });
@@ -72,7 +71,6 @@ function displayVideo(url, title, push) {
       vidType = 'vimeo';
       const vid = new URL(url).pathname.split('/')[1];
       vidUrl = `https://player.vimeo.com/video/${vid}?app_id=122963&autoplay=1`;
-      console.log(vidUrl);
     }
     playInlineVideo($video, vidUrl, vidType, title);
   } else {
@@ -82,8 +80,6 @@ function displayVideo(url, title, push) {
 
 function transformToVideoColumn($cell, $a) {
   $cell.classList.add('column-video');
-
-  console.log($a.href);
 
   $cell.addEventListener('click', () => {
     displayVideo($a.href, $a.textContent, true);

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -26,7 +26,7 @@ function playInlineVideo($element, vid, type, title) {
 }
 
 function hideVideo(push) {
-  const $overlay = document.querySelector('main .tutorials-overlay');
+  const $overlay = document.querySelector('main .video-overlay');
   if ($overlay) {
     $overlay.remove();
     window.onkeyup = null;
@@ -40,8 +40,8 @@ function hideVideo(push) {
 function displayVideo(url, title, push) {
   const canPlayInline = url.includes('youtu') || url.includes('vimeo');
   if (canPlayInline) {
-    const $overlay = createTag('div', { class: 'tutorials-overlay' });
-    const $video = createTag('div', { class: 'tutorials-overlay-video', id: 'tutorials-overlay-video' });
+    const $overlay = createTag('div', { class: 'video-overlay' });
+    const $video = createTag('div', { class: 'video-overlay-video', id: 'video-overlay-video' });
     $overlay.appendChild($video);
     $overlay.addEventListener('click', () => {
       hideVideo(true);

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -157,7 +157,6 @@ export default function decorate($block) {
         if (($a.href.includes('vimeo') || $a.href.includes('youtu'))
           && $row.parentElement.classList.contains('highlight')) {
           transformToVideoColumn($cell, $a);
-          $a.remove();
         }
         if ($a.textContent.startsWith('https://')) {
           if ($a.href.endsWith('.mp4')) {

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -205,7 +205,8 @@ export default function decorate($block) {
       // this probably needs to be tighter and possibly earlier
       const $a = $cell.querySelector('a');
       if ($a) {
-        if ($a.href.includes('vimeo') && $row.parentElement.classList.contains('highlight')) {
+        if (($a.href.includes('vimeo') || $a.href.includes('youtu'))
+          && $row.parentElement.classList.contains('highlight')) {
           transformToVideoColumn($cell, $a);
           $a.remove();
         }

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -24,12 +24,16 @@ import {
 } from '../shared/video.js';
 
 function transformToVideoColumn($cell, $a) {
-  $cell.classList.add('column-video');
+  const $parent = $cell.parentElement;
 
-  $cell.addEventListener('click', () => {
+  $cell.classList.add('column-video');
+  $parent.classList.add('columns-video');
+
+  $parent.addEventListener('click', () => {
     displayVideoModal($a.href, $a.textContent, true);
   });
-  $cell.addEventListener('keyup', ({ key }) => {
+
+  $parent.addEventListener('keyup', ({ key }) => {
     if (key === 'Enter') {
       displayVideoModal($a.href, $a.textContent);
     }

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -157,6 +157,10 @@ export default function decorate($block) {
         if (($a.href.includes('vimeo') || $a.href.includes('youtu'))
           && $row.parentElement.classList.contains('highlight')) {
           transformToVideoColumn($cell, $a);
+
+          $a.addEventListener('click', (e) => {
+            e.preventDefault();
+          });
         }
         if ($a.textContent.startsWith('https://')) {
           if ($a.href.endsWith('.mp4')) {

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -14,79 +14,24 @@ import {
   linkImage,
   createTag,
   transformLinkToAnimation,
-  addAnimationToggle, toClassName,
+  addAnimationToggle,
 // eslint-disable-next-line import/no-unresolved
 } from '../../scripts/scripts.js';
 
-const docTitle = document.title;
-
-function playInlineVideo($element, vid, type, title) {
-  $element.innerHTML = `<iframe src="${vid}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen title="${title}"></iframe>`;
-  $element.classList.add(type);
-}
-
-function hideVideo(push) {
-  const $overlay = document.querySelector('main .video-overlay');
-  if ($overlay) {
-    $overlay.remove();
-    window.onkeyup = null;
-  }
-  if (push) {
-    // create new history entry
-    window.history.pushState({}, docTitle, window.location.href.split('#')[0]);
-  }
-}
-
-function displayVideo(url, title, push) {
-  const canPlayInline = url.includes('youtu') || url.includes('vimeo');
-  if (canPlayInline) {
-    const $overlay = createTag('div', { class: 'video-overlay' });
-    const $video = createTag('div', { class: 'video-overlay-video', id: 'video-overlay-video' });
-    $overlay.appendChild($video);
-    $overlay.addEventListener('click', () => {
-      hideVideo(true);
-    });
-    window.onkeyup = ({ key }) => {
-      if (key === 'Escape') {
-        hideVideo(true);
-      }
-    };
-    if (push) {
-      // create new history entry
-      window.history.pushState({ url, title }, `${docTitle} | ${title}`, `#${toClassName(title)}`);
-    }
-    const $main = document.querySelector('main');
-    $main.append($overlay);
-    let vidUrl = '';
-    let vidType = 'default';
-    if (url.includes('youtu')) {
-      vidType = 'youtube';
-      const yturl = new URL(url);
-      let vid = yturl.searchParams.get('v');
-      if (!vid) {
-        vid = yturl.pathname.substr(1);
-      }
-      vidUrl = `https://www.youtube.com/embed/${vid}?feature=oembed&autoplay=1`;
-    } else if (url.includes('vimeo')) {
-      vidType = 'vimeo';
-      const vid = new URL(url).pathname.split('/')[1];
-      vidUrl = `https://player.vimeo.com/video/${vid}?app_id=122963&autoplay=1`;
-    }
-    playInlineVideo($video, vidUrl, vidType, title);
-  } else {
-    window.location.href = url;
-  }
-}
+import {
+  displayVideoModal,
+  hideVideoModal,
+} from '../shared/video.js';
 
 function transformToVideoColumn($cell, $a) {
   $cell.classList.add('column-video');
 
   $cell.addEventListener('click', () => {
-    displayVideo($a.href, $a.textContent, true);
+    displayVideoModal($a.href, $a.textContent, true);
   });
   $cell.addEventListener('keyup', ({ key }) => {
     if (key === 'Enter') {
-      displayVideo($a.href, $a.textContent);
+      displayVideoModal($a.href, $a.textContent);
     }
   });
 }
@@ -257,10 +202,10 @@ export default function decorate($block) {
 
       // handle history events
       window.addEventListener('popstate', ({ state }) => {
-        hideVideo();
+        hideVideoModal();
         const { url, title } = state;
         if (url) {
-          displayVideo(url, title);
+          displayVideoModal(url, title);
         }
       });
 

--- a/express/blocks/shared/video.js
+++ b/express/blocks/shared/video.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  createTag, toClassName,
+// eslint-disable-next-line import/no-unresolved
+} from '../../scripts/scripts.js';
+
+const docTitle = document.title;
+
+function playInlineVideo($element, vid, type, title) {
+  $element.innerHTML = `<iframe src="${vid}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen title="${title}"></iframe>`;
+  $element.classList.add(type);
+}
+
+export function hideVideoModal(push) {
+  const $overlay = document.querySelector('main .video-overlay');
+  if ($overlay) {
+    $overlay.remove();
+    window.onkeyup = null;
+  }
+  if (push) {
+    // create new history entry
+    window.history.pushState({}, docTitle, window.location.href.split('#')[0]);
+  }
+}
+
+export function displayVideoModal(url, title, push) {
+  const canPlayInline = url.includes('youtu') || url.includes('vimeo');
+  if (canPlayInline) {
+    const $overlay = createTag('div', { class: 'video-overlay' });
+    const $video = createTag('div', { class: 'video-overlay-video', id: 'video-overlay-video' });
+    $overlay.appendChild($video);
+    $overlay.addEventListener('click', () => {
+      hideVideoModal(true);
+    });
+    window.onkeyup = ({ key }) => {
+      if (key === 'Escape') {
+        hideVideoModal(true);
+      }
+    };
+    if (push) {
+      // create new history entry
+      window.history.pushState({ url, title }, `${docTitle} | ${title}`, `#${toClassName(title)}`);
+    }
+    const $main = document.querySelector('main');
+    $main.append($overlay);
+    let vidUrl = '';
+    let vidType = 'default';
+    if (url.includes('youtu')) {
+      vidType = 'youtube';
+      const yturl = new URL(url);
+      let vid = yturl.searchParams.get('v');
+      if (!vid) {
+        vid = yturl.pathname.substr(1);
+      }
+      vidUrl = `https://www.youtube.com/embed/${vid}?feature=oembed&autoplay=1`;
+    } else if (url.includes('vimeo')) {
+      vidType = 'vimeo';
+      const vid = new URL(url).pathname.split('/')[1];
+      vidUrl = `https://player.vimeo.com/video/${vid}?app_id=122963&autoplay=1`;
+    }
+    playInlineVideo($video, vidUrl, vidType, title);
+  } else {
+    window.location.href = url;
+  }
+}

--- a/express/blocks/tutorials/tutorials.css
+++ b/express/blocks/tutorials/tutorials.css
@@ -74,7 +74,7 @@ main .tutorials h3 {
   font-weight: 700;
 }
 
-main .tutorials-overlay {
+main .video-overlay {
   position: fixed;
   top: 0;
   bottom: 0;
@@ -87,20 +87,20 @@ main .tutorials-overlay {
   z-index: 10;
 }
 
-main .tutorials-overlay .tutorials-overlay-video {
+main .video-overlay .video-overlay-video {
   width: 90vw;
   height: calc(90vw * 9 / 16);
   max-height: 100vh;
 }
 
-main .tutorials-overlay .tutorials-overlay-video.vimeo {
+main .video-overlay .video-overlay-video.vimeo {
   width: 90vh;
   max-width: 90vw;
   height: 90vw;
   max-height: 90vh;
 }
 
-main .tutorials-overlay .tutorials-overlay-video iframe {
+main .video-overlay .video-overlay-video iframe {
   width: 100%;
   height: 100%;
 }

--- a/express/blocks/tutorials/tutorials.js
+++ b/express/blocks/tutorials/tutorials.js
@@ -17,65 +17,10 @@ import {
 // eslint-disable-next-line import/no-unresolved
 } from '../../scripts/scripts.js';
 
-const docTitle = document.title;
-
-function playInlineVideo($element, vid, type, title) {
-  $element.innerHTML = `<iframe src="${vid}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen title="${title}"></iframe>`;
-  $element.classList.add(type);
-}
-
-function hideTutorial(push) {
-  const $overlay = document.querySelector('main .tutorials-overlay');
-  if ($overlay) {
-    $overlay.remove();
-    window.onkeyup = null;
-  }
-  if (push) {
-    // create new history entry
-    window.history.pushState({}, docTitle, window.location.href.split('#')[0]);
-  }
-}
-
-function displayTutorial(url, title, push) {
-  const canPlayInline = url.includes('youtu') || url.includes('vimeo');
-  if (canPlayInline) {
-    const $overlay = createTag('div', { class: 'tutorials-overlay' });
-    const $video = createTag('div', { class: 'tutorials-overlay-video', id: 'tutorials-overlay-video' });
-    $overlay.appendChild($video);
-    $overlay.addEventListener('click', () => {
-      hideTutorial(true);
-    });
-    window.onkeyup = ({ key }) => {
-      if (key === 'Escape') {
-        hideTutorial(true);
-      }
-    };
-    if (push) {
-      // create new history entry
-      window.history.pushState({ url, title }, `${docTitle} | ${title}`, `#${toClassName(title)}`);
-    }
-    const $main = document.querySelector('main');
-    $main.append($overlay);
-    let vidUrl = '';
-    let vidType = 'default';
-    if (url.includes('youtu')) {
-      vidType = 'youtube';
-      const yturl = new URL(url);
-      let vid = yturl.searchParams.get('v');
-      if (!vid) {
-        vid = yturl.pathname.substr(1);
-      }
-      vidUrl = `https://www.youtube.com/embed/${vid}?feature=oembed&autoplay=1`;
-    } else if (url.includes('vimeo')) {
-      vidType = 'vimeo';
-      const vid = new URL(url).pathname.split('/')[1];
-      vidUrl = `https://player.vimeo.com/video/${vid}?app_id=122963&autoplay=1`;
-    }
-    playInlineVideo($video, vidUrl, vidType, title);
-  } else {
-    window.location.href = url;
-  }
-}
+import {
+  displayVideoModal,
+  hideVideoModal,
+} from '../shared/video.js';
 
 function createTutorialCard(title, url, time, $picture) {
   const $card = createTag('a', { class: 'tutorial-card', title, tabindex: 0 });
@@ -87,11 +32,11 @@ function createTutorialCard(title, url, time, $picture) {
   const $cardBottom = createTag('div', { class: 'tutorial-card-text' });
   $cardBottom.innerHTML = `<h3>${title}</h3>`;
   $card.addEventListener('click', () => {
-    displayTutorial(url, title, true);
+    displayVideoModal(url, title, true);
   });
   $card.addEventListener('keyup', ({ key }) => {
     if (key === 'Enter') {
-      displayTutorial(url, title);
+      displayVideoModal(url, title);
     }
   });
   $card.appendChild($cardTop);
@@ -110,15 +55,15 @@ function decorateTutorials($block) {
     $block.appendChild($card);
     $tutorial.remove();
     if (toClassName(title) === window.location.hash.substr(1)) {
-      displayTutorial(url, title);
+      displayVideoModal(url, title);
     }
   });
   // handle history events
   window.addEventListener('popstate', ({ state }) => {
-    hideTutorial();
+    hideVideoModal();
     const { url, title } = state;
     if (url) {
-      displayTutorial(url, title);
+      displayVideoModal(url, title);
     }
   });
 }


### PR DESCRIPTION
Fix https://github.com/adobe/express-website-issues/issues/305

I've imported the identical video player from the tutorials block into the columns block. It seems to follow the specs recommended. 

As per the discussion with Raphael, this functionality is only enabled for highlight column blocks.

I did not add the hover animation as it is marked as optional, and I am struggling to place the overlay due to the div and image have no set height. I will continue to work on this and if PR is not merged by then, I will commit the feature addition.

I feel like the .video-overlay part could potentially be placed within its own global css file and the JS could probably be exported and used globally as well, but for now I restricted myself to only implementing it for this block.

You can test the implementation here:

https://main--express-website--adobe.hlx3.page/drafts/nipun/registration-vimeo