### PR TITLE
fix: review how-to carousel loading and sizing logic

### DIFF
--- a/express/blocks/how-to-steps-carousel/how-to-steps-carousel.css
+++ b/express/blocks/how-to-steps-carousel/how-to-steps-carousel.css
@@ -176,6 +176,7 @@ main .how-to-steps-carousel-container .icon {
   main .how-to-steps-carousel-container {
     display: flex;
     justify-content: center;
+    align-items: start;
   }
 
   main .how-to-steps-carousel-container > div {

--- a/express/blocks/how-to-steps-carousel/how-to-steps-carousel.css
+++ b/express/blocks/how-to-steps-carousel/how-to-steps-carousel.css
@@ -184,6 +184,7 @@ main .how-to-steps-carousel-container .icon {
     padding: 80px 70px;
     width: 50%;
     height: 100%;
+    max-width: 600px;
   }
 
   main .how-to-steps-carousel-container > picture > img {
@@ -204,12 +205,6 @@ main .how-to-steps-carousel-container .icon {
 }
 
 @media (min-width: 1200px) {
-  main .how-to-steps-carousel-container {
-    max-width: 1600px;
-    margin-left: auto; 
-    margin-right: auto; 
-  }
-
   main .how-to-steps-carousel-container.no-cover > div {
     margin: 0 120px 0 20px;
   }

--- a/express/blocks/how-to-steps-carousel/how-to-steps-carousel.css
+++ b/express/blocks/how-to-steps-carousel/how-to-steps-carousel.css
@@ -203,6 +203,12 @@ main .how-to-steps-carousel-container .icon {
 }
 
 @media (min-width: 1200px) {
+  main .how-to-steps-carousel-container {
+    max-width: 1600px;
+    margin-left: auto; 
+    margin-right: auto; 
+  }
+
   main .how-to-steps-carousel-container.no-cover > div {
     margin: 0 120px 0 20px;
   }

--- a/express/blocks/how-to-steps-carousel/how-to-steps-carousel.css
+++ b/express/blocks/how-to-steps-carousel/how-to-steps-carousel.css
@@ -160,10 +160,9 @@ main .how-to-steps-carousel-container .icon {
     margin-bottom: 80px;
     object-position: right;
     object-fit: cover;
-    min-width: 100%;
-    max-width: 100%;
     min-height: 100%;
     max-height: 100%;
+    width: unset;
   }
 
   main .how-to-steps-carousel .tips .tip {

--- a/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
+++ b/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
@@ -175,6 +175,16 @@ export default function decorate(block) {
     });
   }
 
-  activate(block, block.querySelector('.tip-number.tip-1'));
-  initRotation(window, document);
+  const img = picture.querySelector('img');
+  const run = () => {
+    activate(block, block.querySelector('.tip-number.tip-1'));
+    initRotation(window, document);
+  };
+
+  if (!img.complete) {
+    img.addEventListener('load', run);
+    img.addEventListener('error', run);
+  } else {
+    run();
+  }
 }

--- a/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
+++ b/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
@@ -175,5 +175,6 @@ export default function decorate(block) {
     });
   }
 
+  activate(block, block.querySelector('.tip-number.tip-1'));
   initRotation(window, document);
 }

--- a/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
+++ b/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
@@ -54,12 +54,11 @@ function activate(block, target) {
       const picture = container.querySelector('picture');
       const img = picture.querySelector('img');
       const panelHeight = block.parentElement.offsetHeight;
-      const imgHeight = img.offsetHeight;
-      if (imgHeight > panelHeight) {
-        picture.style.height = `${panelHeight}px`;
+      const imgHeight = img.naturalHeight;
+      if (imgHeight < panelHeight) {
         container.classList.add('no-cover');
       } else {
-        picture.style.height = `${imgHeight}px`;
+        picture.style.height = `${panelHeight}px`;
       }
     }
 


### PR DESCRIPTION
User reported random image size on page: https://main--express-website--adobe.hlx3.page/drafts/nipun/inform-introduce-engage.

I think all the pages have a similar issue but it gets fixed after 5s when step rotation occurs. Usually, the block is below the folder, i.e. the issue is not visible.

Attempt to fix (including some other pages):
- https://main--express-website--adobe.hlx3.page/drafts/nipun/inform-introduce-engage vs https://fix-carousel-wrong-image-size--express-website--adobe.hlx3.page/drafts/nipun/inform-introduce-engage?martech=off
- https://main--express-website--adobe.hlx3.page/express/create/flyer vs https://fix-carousel-wrong-image-size--express-website--adobe.hlx3.page/express/create/flyer?martech=off
- https://main--express-website--adobe.hlx3.page/express/create/banner vs https://fix-carousel-wrong-image-size--express-website--adobe.hlx3.page/express/create/banner?martech=off

Pretty complex block with a lot of edge cases but PR result looks better and stable.