### PR TITLE
fix(pricing): price formatting issue

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -439,7 +439,7 @@ function getCurrencyDisplay(currency) {
 export function formatPrice(price, currency) {
   const locale = ['USD', 'TWD'].includes(currency)
     ? 'en-GB' // use en-GB for intl $ symbol formatting
-    : getCountry();
+    : getLanguage(getCountry());
   const currencyDisplay = getCurrencyDisplay(currency);
   return new Intl.NumberFormat(locale, {
     style: 'currency',


### PR DESCRIPTION
Wrong currency delimiter:
https://www.adobe.com/express/pricing?country=se
https://www.adobe.com/express/pricing?country=dk
https://www.adobe.com/express/pricing?country=br
vs:
https://price-format-fix--express-website--adobe.hlx3.page/express/pricing?country=se&lighthouse=on