### PR TITLE
feat('quick-action-cards): ability to add in-line links like 'Learn more'

### DIFF
--- a/express/blocks/quick-action-cards/quick-action-cards.css
+++ b/express/blocks/quick-action-cards/quick-action-cards.css
@@ -66,7 +66,27 @@ main .quick-action-cards .quick-action-card {
   text-align: left;
 }
 
-main .quick-action-cards .quick-action-card > div:not(.quick-action-card-image) {
+main .quick-action-cards .quick-action-card p.button-container {
+  display: inline-block;
+}
+
+main .quick-action-cards .quick-action-card p.button-container a:not(.button) {
+  padding: 5px 1.2em 6px 1.2em;
+  margin: 0;
+  font-size: var(--body-font-size-s);
+  overflow: hidden;
+  display: inline-block;
+}
+
+main .quick-action-cards .quick-action-card p.button-container a:not(.button) .icon {
+  height: 8px;
+  width: 8px;
+  margin-left: 4px;
+  transform: rotate(270deg) translateY(1px);
+  fill: currentColor;
+}
+
+main .quick-action-cards .quick-action-card div:not(.quick-action-card-image) {
   padding: 20px;
 }
 

--- a/express/blocks/quick-action-cards/quick-action-cards.js
+++ b/express/blocks/quick-action-cards/quick-action-cards.js
@@ -19,24 +19,38 @@ import {
 
 export default function decorate($block) {
   const $cards = Array.from($block.querySelectorAll(':scope>div'));
+  const chevron = getIcon('chevron');
   $cards.forEach(($card) => {
     $card.classList.add('quick-action-card');
     const $cardDivs = [...$card.children];
     $cardDivs.forEach(($div) => {
-      if ($div.querySelector('img')) {
+      if ($div.querySelector(':scope > picture:first-child')) {
         $div.classList.add('quick-action-card-image');
-      }
-      const $a = $div.querySelector('a');
-      if ($a && $a.textContent.startsWith('https://')) {
-        const $wrapper = createTag('a', { href: $a.href, class: 'quick-action-card' });
-        $a.remove();
-        $wrapper.innerHTML = $card.innerHTML;
-        $block.replaceChild($wrapper, $card);
+        const $a = $div.querySelector('a');
+        if ($a && $a.textContent.startsWith('https://')) {
+          const contents = Array.from($card.children);
+          const $wrapper = createTag('a', { href: $a.href });
+          $a.remove();
+          $card.appendChild($wrapper);
+          contents.forEach((child) => {
+            $wrapper.appendChild(child);
+          });
+        }
+      } else {
+        const $buttons = $div.querySelectorAll(':scope a');
+        for (let index = 0; index < $buttons.length; index += 1) {
+          if (index > 0) {
+            $buttons[index].insertAdjacentHTML('beforeend', chevron);
+            $buttons[index].classList.remove('button');
+            $buttons[index].classList.remove('primary');
+            $buttons[index].classList.remove('secondary');
+            $buttons[index].classList.remove('accent');
+          }
+        }
       }
     });
   });
   if ($cards.length > 3) {
-    const chevron = getIcon('chevron');
     const $seeMore = document.createElement('a');
     $seeMore.classList.add('quick-action-card--open');
     $seeMore.classList.add('button');


### PR DESCRIPTION
Continuation of https://github.com/adobe/express-website/pull/306

XD Spec: https://xd.adobe.com/view/858f0156-6fe3-441a-8e53-a39cc8be79fc-d0dc/screen/fa5483b0-3d01-4c69-a5b4-2068f5f78f3d/

Test URL: https://quick-action-cards--express-website--webistry-development.hlx3.page/drafts/rofe/feature/quick-actions

The first link will remain a button, and the following links will become normal links with a chevron >

Before:
![image](https://user-images.githubusercontent.com/62023521/150387831-c2d8fc9a-4eb7-4382-81aa-d3c51b12f896.png)

After: 
![image](https://user-images.githubusercontent.com/62023521/150387869-27a084c8-cacb-4148-b752-c0929ff5c086.png)

Please be sure to update the 'learn more' links in authoring to the correct link, I simply copied the same one for testing purposes
