### PR TITLE
fix: connect to pricing column

### DIFF
--- a/express/blocks/pricing-modal/pricing-modal.js
+++ b/express/blocks/pricing-modal/pricing-modal.js
@@ -84,7 +84,8 @@ function decoratePricingModal($block) {
   const $headerClose = createTag('a', { class: 'close' });
   $headerClose.classList.add('modal-header-close');
   $headerClose.addEventListener('click', closePopup);
-  const $cta = document.querySelector('a.cta.large');
+  const ctas = document.querySelectorAll('a.pricing-columns-cta.large');
+  const $cta = ctas ? ctas[ctas.length - 1] : null;
   if ($cta) {
     $cta.addEventListener('click', displayPopup);
     const $continue = $block.querySelector(':scope .button-container:last-of-type a.button');


### PR DESCRIPTION
Fix https://github.com/adobe/express-website-issues/issues/310

To test: 
- open https://repair-puf-modal--express-website--adobe.hlx3.page/drafts/alex/pricing?pricing-modal=on
- click on the `Start your 30-day free trial` button

The Word document must contain the `Pricing Modal` block including the correctly formatted content, otherwise, no modal shown.