### PR TITLE
fix-bug(quick-action-cards): show more/less affects multiple cards

### DIFF
--- a/express/blocks/quick-action-cards/quick-action-cards.css
+++ b/express/blocks/quick-action-cards/quick-action-cards.css
@@ -116,11 +116,11 @@ main .quick-action-cards.quick-action-cards--expanded .quick-action-card {
   display: block;
 }
 
-main .quick-action-cards.quick-action-cards--expanded ~ .quick-action-cards--buttons .quick-action-card--close {
+main .quick-action-cards.quick-action-cards--expanded + .quick-action-cards--buttons .quick-action-card--close {
   display: inline-block;
 }
 
-main .quick-action-cards.quick-action-cards--expanded ~ .quick-action-cards--buttons .quick-action-card--open {
+main .quick-action-cards.quick-action-cards--expanded + .quick-action-cards--buttons .quick-action-card--open {
   display: none;
 } 
 


### PR DESCRIPTION
Fix bug where show/less button affects other blocks as well.

Test URL: https://quick-action-cards--express-website--webistry-development.hlx3.page/drafts/Abhishek/01-25-2022/quick-actions

Fix: https://github.com/adobe/express-website-issues/issues/313