### PR TITLE
fix(how-to-steps): bottom margin too large

### DIFF
--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -16,7 +16,11 @@ main .how-to-steps-container > div {
 
 main .how-to-steps {
   margin-top: 20px;
-  margin-bottom: 120px;
+  margin-bottom: 0;
+}
+
+main .how-to-steps + .block {
+  margin-bottom: 80px;
 }
 
 main .how-to-steps > div {


### PR DESCRIPTION
Fix: https://github.com/adobe/express-website-issues/issues/318

https://main--express-website--adobe.hlx3.page/drafts/nipun/education-deployment
vs
https://issue-318--express-website--adobe.hlx3.page/drafts/nipun/education-deployment?lighthouse=on