### PR TITLE
fix: add title attr to pricing column dropdown

### DIFF
--- a/express/blocks/pricing-columns/pricing-columns.js
+++ b/express/blocks/pricing-columns/pricing-columns.js
@@ -15,6 +15,7 @@
 import {
   addPublishDependencies,
   createTag,
+  fetchPlaceholders,
   getHelixEnv,
   getOffer,
 // eslint-disable-next-line import/no-unresolved
@@ -230,6 +231,9 @@ function decoratePlan($column) {
 
     if (plans.length > 1) {
       const $pricingDropdown = createTag('select', { class: 'pricing-columns-dropdown' });
+      fetchPlaceholders().then((placeholders) => {
+        $pricingDropdown.title = placeholders.subscription;
+      });
 
       $pricingDropdown.addEventListener('change', () => {
         selectPlan($pricingHeader, $pricingDropdown.value, true);


### PR DESCRIPTION
## Description

 add a `title` attribute to the pricing column dropdown, title comes from placeholders
changes to the text content of the title can be changed in the placeholders sheet

## Related Issue

fixes [#292](https://github.com/adobe/express-website-issues/issues/292)

## Links

- before: https://www.adobe.com/express/pricing
- after: https://pricing-plan-dropdown-label--express-website--adobe.hlx.live/express/pricing?lighthouse=on