### PR TITLE
fix: pass the correct footer selector to Privacy module

### DIFF
--- a/express/scripts/delayed.js
+++ b/express/scripts/delayed.js
@@ -121,7 +121,7 @@ w.fedsConfig = {
   },
   privacy: {
     otDomainId: '7a5eb705-95ed-4cc4-a11d-0cc5760e93db',
-    footerLinkSelector: '#openCookieModal',
+    footerLinkSelector: '[data-feds-action="open-adchoices-modal"]',
   },
 };
 


### PR DESCRIPTION
## Description
Initializes new Privacy with the correct footer link selector. Clinking on "Cookie Preferences" will show the Preference modal.

https://fix-privacy-modal-link--express-website--adobe.hlx3.page/express/

## Motivation and Context
Allow visitors to update their preferences.

## How Has This Been Tested?
locally

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
