### PR TITLE
fix(quick-actions-cards): 'see less' now scrolls you to the top of the block

### DIFF
--- a/express/blocks/quick-action-cards/quick-action-cards.js
+++ b/express/blocks/quick-action-cards/quick-action-cards.js
@@ -51,6 +51,13 @@ export default function decorate($block) {
     });
   });
   if ($cards.length > 3) {
+    let $top = $block.previousElementSibling;
+    if ($top && $top.tagName === 'P') {
+      $top = $top.previousElementSibling;
+    }
+    if (!['H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes($top.tagName)) {
+      $top = $block;
+    }
     const $seeMore = document.createElement('a');
     $seeMore.classList.add('quick-action-card--open');
     $seeMore.classList.add('button');
@@ -74,6 +81,7 @@ export default function decorate($block) {
     $seeLess.setAttribute('href', 'javascript: void(0)');
     $seeLess.addEventListener('click', () => {
       $block.classList.remove('quick-action-cards--expanded');
+      window.scrollTo(0, $top.offsetTop);
     });
     const $pButton = document.createElement('p');
     if ($block.nextSibling) {


### PR DESCRIPTION
**Issue (reported by Rashmi):**
"Clicking on 'See less' CTA of "Edit your videos" section is redirecting to 'Design made easy for everyone. https://main--express-website--adobe.hlx3.page/drafts/Abhishek/01-25-2022/quick-actions#edit-your-videos"

Fixed by making the 'see less' button reposition you to the top of the block. If it finds a header element directly before the block it will scroll to the top of that header element instead.

**Test URL for the fix**: https://see-less-bug--express-website--webistry-development.hlx3.page/drafts/Abhishek/01-25-2022/quick-actions