### PR TITLE
chore: suppress extra img requests from safari

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1339,10 +1339,10 @@ export function createOptimizedPicture(src, alt = '', eager = false, breakpoints
       picture.appendChild(source);
     } else {
       const img = document.createElement('img');
-      img.setAttribute('src', `${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
       img.setAttribute('loading', eager ? 'eager' : 'lazy');
       img.setAttribute('alt', alt);
       picture.appendChild(img);
+      img.setAttribute('src', `${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
     }
   });
 


### PR DESCRIPTION
https://safari-img-loading--express-website--adobe.hlx3.page/express/?lighthouse=on

vs. 

https://main--express-website--adobe.hlx3.page/express/?lighthouse=on

suppress extra requests from safari loading unnecessary fall back images