### PR TITLE
feat(branch): branch url parameter tracking

### DIFF
--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -371,9 +371,54 @@ loadScript(martechURL, () => {
     digitalData._delete('spark.eventData.eventName');
   }
 
+  function trackBranchParameters($links) {
+    const rootUrl = new URL(loc.href);
+    const rootUrlParameters = rootUrl.searchParams;
+
+    const sdid = rootUrlParameters.get('sdid');
+    const mv = rootUrlParameters.get('mv');
+    const sKwcid = rootUrlParameters.get('s_kwcid');
+    const efId = rootUrlParameters.get('ef_id');
+
+    if (sdid || mv || sKwcid || efId) {
+      $links.forEach(($a) => {
+        const buttonUrl = new URL($a.href);
+        const urlParams = buttonUrl.searchParams;
+
+        if (buttonUrl.href.match('adobesparkpost.app.link')) {
+          if (sdid) {
+            urlParams.set('campaign_id', sdid);
+          }
+
+          if (mv) {
+            urlParams.set('channel', mv);
+          }
+
+          if (sKwcid) {
+            const sKwcidParameters = sKwcid.split('!');
+
+            if (sKwcidParameters[2] === '3') {
+              urlParams.set('ad_partner', 'Google%20AdWords');
+            } // Missing Facebook.
+          }
+
+          urlParams.set('feature', 'paid%20advertising');
+        }
+
+        buttonUrl.search = urlParams.toString();
+        $a.href = buttonUrl.toString();
+      });
+    }
+  }
+
   function decorateAnalyticsEvents() {
+    const $links = d.querySelectorAll('main a');
+
+    // for adding branch parameters to branch links
+    trackBranchParameters($links);
+
     // for tracking all of the links
-    d.querySelectorAll('main a').forEach(($a) => {
+    $links.forEach(($a) => {
       $a.addEventListener('click', () => {
         trackButtonClick($a);
       });

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -398,7 +398,7 @@ loadScript(martechURL, () => {
             const sKwcidParameters = sKwcid.split('!');
 
             if (typeof sKwcidParameters[2] !== 'undefined' && sKwcidParameters[2] === '3') {
-              urlParams.set('ad_partner', 'Google%20AdWords');
+              urlParams.set('~customer_placement', 'Google%20AdWords');
             } // Missing Facebook.
 
             if (typeof sKwcidParameters[8] !== 'undefined' && sKwcidParameters[8] !== '') {

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -397,9 +397,13 @@ loadScript(martechURL, () => {
           if (sKwcid) {
             const sKwcidParameters = sKwcid.split('!');
 
-            if (sKwcidParameters[2] === '3') {
+            if (typeof sKwcidParameters[2] !== 'undefined' && sKwcidParameters[2] === '3') {
               urlParams.set('ad_partner', 'Google%20AdWords');
             } // Missing Facebook.
+
+            if (typeof sKwcidParameters[8] !== 'undefined' && sKwcidParameters[8] !== '') {
+              urlParams.set('keyword', sKwcidParameters[8]);
+            }
           }
 
           urlParams.set('feature', 'paid%20advertising');

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -387,11 +387,11 @@ loadScript(martechURL, () => {
 
         if (buttonUrl.href.match('adobesparkpost.app.link')) {
           if (sdid) {
-            urlParams.set('campaign_id', sdid);
+            urlParams.set('~campaign_id', sdid);
           }
 
           if (mv) {
-            urlParams.set('channel', mv);
+            urlParams.set('~customer_campaign', mv);
           }
 
           if (sKwcid) {
@@ -402,11 +402,11 @@ loadScript(martechURL, () => {
             } // Missing Facebook.
 
             if (typeof sKwcidParameters[8] !== 'undefined' && sKwcidParameters[8] !== '') {
-              urlParams.set('keyword', sKwcidParameters[8]);
+              urlParams.set('~keyword', sKwcidParameters[8]);
             }
           }
 
-          urlParams.set('feature', 'paid%20advertising');
+          urlParams.set('~feature', 'paid%20advertising');
         }
 
         buttonUrl.search = urlParams.toString();


### PR DESCRIPTION
This Pull Request was created in preparation for code review and testing and should not be merged right away. 

### Test URLs

(contains no branch urls)
https://branch_tracking--express-website--webistry-development.hlx3.page/express/pricing

(contains branch links)
https://branch_tracking--express-website--webistry-development.hlx3.page/express/create/banner

Feel free to add parameters to the URL in order to test the functionality.

### Information

Currently, this implementation will append any filtered parameters to branch links containing `adobesparkpost.app.link` in the URL.

### Parameters

The function will transpose the following parameters to only branch urls meeting the criteria:

| URL Param| Example | Branch Param | Example
| - | - | - | - |
| sdid  | P3KMQSXK | campaign_id  | P3KMQSXK
| ??? | (need more information) | campaign | NA\|CCX\|AWAR\|Banner\|UseCase_Exact\|GG\|EN
| mv | search | channel | search
| s_kwcid | AL!3085!3!569631820999!e!!g!!custom!15566817297!13399742535<br>The 3rd parameter separated by ! | ad_partner | Google Ads<br>Facebook
| s_kwcid | AL!3085!3!569631820999!e!!g!!custom!15566817297!13399742535<br>The 9th parameter separated by ! | keyword | custom
| none | - | feature | paid advertising

### Notes

I'm unsure as to the proper composition of s_kwcid, is it possible that it doesn't always have eleven parameters? The documentation provided in the issue only mentions five parameters, but the example provided here has eleven.

I'm not entirely sure where the `campaign` branch parameter information is supposed to be fetched from, because it wasn't outlined in the possible URL parameters.

As for the ad_partner, should they be transposed as a number, or as a specific string? If a specific string, what is the digit to recognise Facebook campaigns within s_kwcid.

If you plan to involve more ad_partner possible options in the future, maybe it would be better to pull only the raw value from the s_kwcid or the campaign_tag_name and sending that over instead of having to filter them.