### PR TITLE
chore: use white links in dark option

### DIFF
--- a/express/blocks/hero-animation/hero-animation.css
+++ b/express/blocks/hero-animation/hero-animation.css
@@ -161,7 +161,8 @@ main .hero-animation .hero-animation-overlay p.button-container a.button:any-lin
         padding: 0;
     }
     
-    main .hero-animation.dark {
+    main .hero-animation.dark,
+    main .hero-animation.dark a:any-link {
         color: var(--color-white);
     }
 


### PR DESCRIPTION
Fix #327 

https://issue-327--express-website--adobe.hlx3.page/drafts/rofe/hero-dark?lighthouse=on