### PR TITLE
chore: add support for typographic chevron

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -893,7 +893,8 @@ export function decorateButtons(block = document) {
     }
     if (!noButtonBlocks.includes(blockName)
       && originalHref !== $a.textContent
-      && !$a.textContent.endsWith(' >')) {
+      && !$a.textContent.endsWith(' >')
+      && !$a.textContent.endsWith(' ›')) {
       const $up = $a.parentElement;
       const $twoup = $a.parentElement.parentElement;
       if (!$a.querySelector('img')) {


### PR DESCRIPTION
`>` is easier to type but blunt looking. Authors should be able to use `›` as well.