### PR TITLE
feat: submit email block

### DIFF
--- a/express/blocks/submit-email/submit-email.css
+++ b/express/blocks/submit-email/submit-email.css
@@ -61,6 +61,10 @@
   padding-left: 12px;
 }
 
+.submit-email form .form-block .email-input.error {
+  border: 2px solid #EC5B62;
+}
+
 .submit-email form .form-block .email-input::placeholder { 
   color: var(--color-gray-400);
 }

--- a/express/blocks/submit-email/submit-email.css
+++ b/express/blocks/submit-email/submit-email.css
@@ -1,0 +1,108 @@
+.submit-email-container .submit-email {
+  background-color: #FAFAFA;
+  padding: 56px 16px;
+  border-radius: 20px;
+}
+
+.submit-email > div {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: left;
+}
+
+.submit-email .icon-cc-express-logo, 
+.submit-email .icon-creative-cloud-express {
+  width: 127px;
+  height: 124px;
+}
+
+.submit-email h1 {
+  font-size: var(--heading-font-size-m);
+  font-weight: 900;
+  text-align: left;
+  line-height: 36px;
+  padding: 40px 0px;
+}
+
+.submit-email span {
+  font-size: var(--body-font-size-xs);
+  padding-right: 3px;
+  line-height: 20px;
+}
+
+.submit-email form .form-heading {
+  font-size: var(--body-font-size-xxl);
+  font-weight: bold;
+  text-align: left;
+  margin-bottom: 16px;
+}
+
+.submit-email form .form-heading.success {
+  color: #33AB84;
+}
+
+.submit-email form .form-block {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.submit-email form .form-block > a {
+  margin-left: 0px;
+}
+
+.submit-email form .form-block .email-input {
+  border: 2px solid var(--color-gray-300);
+  border-radius: 6px;
+  width: 215px;
+  height: 32px;
+  margin-bottom: 16px;
+  padding-left: 12px;
+}
+
+.submit-email form .form-block .email-input::placeholder { 
+  color: var(--color-gray-400);
+}
+
+
+@media(min-width: 900px) {
+  .submit-email-container .submit-email {
+    padding: 56px;
+    padding-bottom: 80px;
+  }
+
+  .submit-email > div {
+    flex-direction: row;
+    gap: 40px;
+  }
+
+  .submit-email > div > div:nth-child(1) {
+    flex: 0 0 127px;
+  }
+
+  .submit-email h1 {
+    font-size: var(--heading-font-size-l);
+    line-height: 44px;
+    padding-top: 12px;
+  }
+
+  .submit-email form .form-block {
+    flex-direction: row;
+    gap: 24px;
+  }
+
+  .submit-email form .form-block > a {
+    margin-top: 0px;
+  }
+
+  .submit-email span {
+    display: block;
+  }
+}
+
+@media(min-width: 1200px) {
+  .submit-email span {
+    display: inline-block;
+  }
+}

--- a/express/blocks/submit-email/submit-email.js
+++ b/express/blocks/submit-email/submit-email.js
@@ -15,7 +15,7 @@ function validEmail(email) {
   return emailRegex.test(email);
 }
 
-function decorateSubmitEmailBlock($block) {
+export default function decorate($block) {
   const $container = document.querySelector('.submit-email-container');
 
   const $icon = $container.querySelector('.icon-creative-cloud-express, .icon-cc-express-logo');
@@ -74,8 +74,4 @@ function decorateSubmitEmailBlock($block) {
     span.innerHTML = p.innerHTML;
     p.parentNode.replaceChild(span, p);
   }
-}
-
-export default function decorate($block) {
-  decorateSubmitEmailBlock($block);
 }

--- a/express/blocks/submit-email/submit-email.js
+++ b/express/blocks/submit-email/submit-email.js
@@ -10,6 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
+function validEmail(email) {
+  const emailRegex = /\S+@\S+\.\S+/;
+  return emailRegex.test(email);
+}
+
 function decorateSubmitEmailBlock($block) {
   const $container = document.querySelector('.submit-email-container');
 
@@ -32,6 +37,9 @@ function decorateSubmitEmailBlock($block) {
   $emailInput.classList.add('email-input');
   $emailInput.setAttribute('type', 'email');
   $emailInput.setAttribute('placeholder', 'Email');
+  $emailInput.addEventListener('input', () => {
+    $emailInput.classList.remove('error');
+  });
 
   const $submitButton = document.createElement('a');
   $submitButton.textContent = 'Submit';
@@ -41,10 +49,13 @@ function decorateSubmitEmailBlock($block) {
   $submitButton.addEventListener('click', (e) => {
     e.preventDefault();
     const email = $emailInput.value;
-    if (email) {
+    if (email && validEmail(email)) {
       // TODO: Send email to server
       $formHeading.textContent = 'Thanks for signing up!';
       $formHeading.classList.add('success');
+      $emailInput.classList.remove('error');
+    } else {
+      $emailInput.classList.add('error');
     }
   });
 

--- a/express/blocks/submit-email/submit-email.js
+++ b/express/blocks/submit-email/submit-email.js
@@ -51,11 +51,32 @@ export default function decorate($block) {
     const email = $emailInput.value;
 
     if (email && $form.checkValidity()) {
-      // TODO: Send email to server
-      $formHeading.textContent = 'Thanks for signing up!';
-      $formHeading.classList.add('success');
-      $emailInput.classList.remove('error');
-      $emailInput.value = '';
+      const headers = new Headers();
+      headers.append('Content-Type', 'application/json');
+
+      const body = {
+        sname: 'adbemeta',
+        email,
+        consent_notice: '<div class="disclaimer detail-spectrum-m" style="letter-spacing: 0px; padding-top: 15px;">The Adobe family of companies may keep me informed with personalized emails. See our <a href="https://www.adobe.com/privacy/policy.html" target="_blank">Privacy Policy</a> for more details or to opt-out at any time.</div>',
+        current_url: window.location.href,
+      };
+
+      const requestOptions = {
+        method: 'POST',
+        headers,
+        body,
+      };
+
+      fetch('https://www.adobe.com/api2/subscribe_v1', requestOptions)
+        .then(() => {
+          $formHeading.textContent = 'Thanks for signing up!';
+          $formHeading.classList.add('success');
+          $emailInput.classList.remove('error');
+          $emailInput.value = '';
+        })
+        .catch(() => {
+          $formHeading.textContent = 'An error occurred during subscription';
+        });
     } else {
       $emailInput.classList.add('error');
       $form.reportValidity();

--- a/express/blocks/submit-email/submit-email.js
+++ b/express/blocks/submit-email/submit-email.js
@@ -10,23 +10,22 @@
  * governing permissions and limitations under the License.
  */
 
-function decorateSubmitEmailBlock($block) {
+function decorateSubmitEmailBlock(block) {
   const container = document.querySelector('.submit-email-container');
 
   const icon = container.querySelector('.icon-creative-cloud-express, .icon-cc-express-logo');
-  const block = container.querySelector('.submit-email');
 
   // Remove submit-email block wrapping div
   const blockParentDiv = block.parentElement;
   container.insertBefore(block, container.firstChild);
-  container.removeChild(blockParentDiv)
+  container.removeChild(blockParentDiv);
   icon.setAttribute('src', '/express/icons/creative-cloud-express.svg');
 
   const heading = container.querySelector('h1');
 
   const form = document.createElement('form');
   const formHeading = document.createElement('h2');
-  formHeading.textContent = "Subscribe Now";
+  formHeading.textContent = 'Subscribe Now';
   formHeading.classList.add('form-heading');
 
   const emailInput = document.createElement('input');
@@ -35,16 +34,16 @@ function decorateSubmitEmailBlock($block) {
   emailInput.setAttribute('placeholder', 'Email');
 
   const submitButton = document.createElement('a');
-  submitButton.textContent = "Submit";
+  submitButton.textContent = 'Submit';
   submitButton.setAttribute('href', '');
   submitButton.classList.add('button');
   submitButton.classList.add('accent');
-  submitButton.addEventListener('click', function (e) {
+  submitButton.addEventListener('click', (e) => {
     e.preventDefault();
     const email = emailInput.value;
     if (email) {
       // TODO: Send email to server
-      formHeading.textContent = "Thanks for signing up!";
+      formHeading.textContent = 'Thanks for signing up!';
       formHeading.classList.add('success');
     }
   });
@@ -61,7 +60,7 @@ function decorateSubmitEmailBlock($block) {
   // Change p to spans
   const paragraphs = block.querySelectorAll('p');
   for (const p of paragraphs) {
-    var span = document.createElement('span');
+    const span = document.createElement('span');
     span.innerHTML = p.innerHTML;
     p.parentNode.replaceChild(span, p);
   }

--- a/express/blocks/submit-email/submit-email.js
+++ b/express/blocks/submit-email/submit-email.js
@@ -13,13 +13,10 @@
 export default function decorate($block) {
   const $container = document.querySelector('.submit-email-container');
 
-  const $icon = $container.querySelector('.icon-creative-cloud-express, .icon-cc-express-logo');
-
   // Remove submit-email block wrapping div
   const $blockParentDiv = $block.parentElement;
   $container.insertBefore($block, $container.firstChild);
   $container.removeChild($blockParentDiv);
-  $icon.setAttribute('src', '/express/icons/creative-cloud-express.svg');
 
   const $heading = $container.querySelector('h1');
 

--- a/express/blocks/submit-email/submit-email.js
+++ b/express/blocks/submit-email/submit-email.js
@@ -10,56 +10,55 @@
  * governing permissions and limitations under the License.
  */
 
-function decorateSubmitEmailBlock(block) {
-  const container = document.querySelector('.submit-email-container');
+function decorateSubmitEmailBlock($block) {
+  const $container = document.querySelector('.submit-email-container');
 
-  const icon = container.querySelector('.icon-creative-cloud-express, .icon-cc-express-logo');
+  const $icon = $container.querySelector('.icon-creative-cloud-express, .icon-cc-express-logo');
 
   // Remove submit-email block wrapping div
-  const blockParentDiv = block.parentElement;
-  container.insertBefore(block, container.firstChild);
-  container.removeChild(blockParentDiv);
-  icon.setAttribute('src', '/express/icons/creative-cloud-express.svg');
+  const $blockParentDiv = $block.parentElement;
+  $container.insertBefore($block, $container.firstChild);
+  $container.removeChild($blockParentDiv);
+  $icon.setAttribute('src', '/express/icons/creative-cloud-express.svg');
 
-  const heading = container.querySelector('h1');
+  const $heading = $container.querySelector('h1');
 
-  const form = document.createElement('form');
-  const formHeading = document.createElement('h2');
-  formHeading.textContent = 'Subscribe Now';
-  formHeading.classList.add('form-heading');
+  const $form = document.createElement('form');
+  const $formHeading = document.createElement('h2');
+  $formHeading.textContent = 'Subscribe Now';
+  $formHeading.classList.add('form-heading');
 
-  const emailInput = document.createElement('input');
-  emailInput.classList.add('email-input');
-  emailInput.setAttribute('type', 'email');
-  emailInput.setAttribute('placeholder', 'Email');
+  const $emailInput = document.createElement('input');
+  $emailInput.classList.add('email-input');
+  $emailInput.setAttribute('type', 'email');
+  $emailInput.setAttribute('placeholder', 'Email');
 
-  const submitButton = document.createElement('a');
-  submitButton.textContent = 'Submit';
-  submitButton.setAttribute('href', '');
-  submitButton.classList.add('button');
-  submitButton.classList.add('accent');
-  submitButton.addEventListener('click', (e) => {
+  const $submitButton = document.createElement('a');
+  $submitButton.textContent = 'Submit';
+  $submitButton.setAttribute('href', '');
+  $submitButton.classList.add('button');
+  $submitButton.classList.add('accent');
+  $submitButton.addEventListener('click', (e) => {
     e.preventDefault();
-    const email = emailInput.value;
+    const email = $emailInput.value;
     if (email) {
       // TODO: Send email to server
-      formHeading.textContent = 'Thanks for signing up!';
-      formHeading.classList.add('success');
+      $formHeading.textContent = 'Thanks for signing up!';
+      $formHeading.classList.add('success');
     }
   });
 
-  const formBlock = document.createElement('div');
-  formBlock.classList.add('form-block');
-  formBlock.appendChild(emailInput);
-  formBlock.appendChild(submitButton);
-  form.appendChild(formHeading);
-  form.appendChild(formBlock);
+  const $formBlock = document.createElement('div');
+  $formBlock.classList.add('form-block');
+  $formBlock.appendChild($emailInput);
+  $formBlock.appendChild($submitButton);
+  $form.appendChild($formHeading);
+  $form.appendChild($formBlock);
 
-  heading.after(form);
+  $heading.after($form);
 
   // Change p to spans
-  const paragraphs = block.querySelectorAll('p');
-  for (const p of paragraphs) {
+  for (const p of $block.querySelectorAll('p')) {
     const span = document.createElement('span');
     span.innerHTML = p.innerHTML;
     p.parentNode.replaceChild(span, p);

--- a/express/blocks/submit-email/submit-email.js
+++ b/express/blocks/submit-email/submit-email.js
@@ -10,11 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-function validEmail(email) {
-  const emailRegex = /\S+@\S+\.\S+/;
-  return emailRegex.test(email);
-}
-
 export default function decorate($block) {
   const $container = document.querySelector('.submit-email-container');
 
@@ -33,15 +28,20 @@ export default function decorate($block) {
   $formHeading.textContent = 'Subscribe Now';
   $formHeading.classList.add('form-heading');
 
+  const $submitButton = document.createElement('a');
   const $emailInput = document.createElement('input');
   $emailInput.classList.add('email-input');
   $emailInput.setAttribute('type', 'email');
   $emailInput.setAttribute('placeholder', 'Email');
-  $emailInput.addEventListener('input', () => {
+  $emailInput.addEventListener('keydown', (e) => {
     $emailInput.classList.remove('error');
+    const key = e.key || e.keyCode;
+    if (key === 13 || key === 'Enter') {
+      e.preventDefault();
+      $submitButton.click();
+    }
   });
 
-  const $submitButton = document.createElement('a');
   $submitButton.textContent = 'Submit';
   $submitButton.setAttribute('href', '');
   $submitButton.classList.add('button');
@@ -49,13 +49,16 @@ export default function decorate($block) {
   $submitButton.addEventListener('click', (e) => {
     e.preventDefault();
     const email = $emailInput.value;
-    if (email && validEmail(email)) {
+
+    if (email && $form.checkValidity()) {
       // TODO: Send email to server
       $formHeading.textContent = 'Thanks for signing up!';
       $formHeading.classList.add('success');
       $emailInput.classList.remove('error');
+      $emailInput.value = '';
     } else {
       $emailInput.classList.add('error');
+      $form.reportValidity();
     }
   });
 

--- a/express/blocks/submit-email/submit-email.js
+++ b/express/blocks/submit-email/submit-email.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+function decorateSubmitEmailBlock($block) {
+  const container = document.querySelector('.submit-email-container');
+
+  const icon = container.querySelector('.icon-creative-cloud-express, .icon-cc-express-logo');
+  const block = container.querySelector('.submit-email');
+
+  // Remove submit-email block wrapping div
+  const blockParentDiv = block.parentElement;
+  container.insertBefore(block, container.firstChild);
+  container.removeChild(blockParentDiv)
+  icon.setAttribute('src', '/express/icons/creative-cloud-express.svg');
+
+  const heading = container.querySelector('h1');
+
+  const form = document.createElement('form');
+  const formHeading = document.createElement('h2');
+  formHeading.textContent = "Subscribe Now";
+  formHeading.classList.add('form-heading');
+
+  const emailInput = document.createElement('input');
+  emailInput.classList.add('email-input');
+  emailInput.setAttribute('type', 'email');
+  emailInput.setAttribute('placeholder', 'Email');
+
+  const submitButton = document.createElement('a');
+  submitButton.textContent = "Submit";
+  submitButton.setAttribute('href', '');
+  submitButton.classList.add('button');
+  submitButton.classList.add('accent');
+  submitButton.addEventListener('click', function (e) {
+    e.preventDefault();
+    const email = emailInput.value;
+    if (email) {
+      // TODO: Send email to server
+      formHeading.textContent = "Thanks for signing up!";
+      formHeading.classList.add('success');
+    }
+  });
+
+  const formBlock = document.createElement('div');
+  formBlock.classList.add('form-block');
+  formBlock.appendChild(emailInput);
+  formBlock.appendChild(submitButton);
+  form.appendChild(formHeading);
+  form.appendChild(formBlock);
+
+  heading.after(form);
+
+  // Change p to spans
+  const paragraphs = block.querySelectorAll('p');
+  for (const p of paragraphs) {
+    var span = document.createElement('span');
+    span.innerHTML = p.innerHTML;
+    p.parentNode.replaceChild(span, p);
+  }
+}
+
+export default function decorate($block) {
+  decorateSubmitEmailBlock($block);
+}


### PR DESCRIPTION
Adds an email capture blade as per [this issue](https://github.com/adobe/express-website-issues/issues/325).

Sample content
https://adobe.sharepoint.com/:w:/r/sites/CC-Express/_layouts/15/doc.aspx?sourcedoc=%7Ba848055e-f0c4-42da-8750-9506d1c74267%7D&action=edit

Test URL: https://submit-email-block--express-website--adobe.hlx3.page/express/campaigns/adbemeta-dev?lighthouse=on

Todo:
- [x] Send email to Campaign once details are provided by [timliu-adobe](https://github.com/timliu-adobe)