### PR TITLE
fix: stringify POST body

### DIFF
--- a/express/blocks/submit-email/submit-email.js
+++ b/express/blocks/submit-email/submit-email.js
@@ -61,7 +61,7 @@ export default function decorate($block) {
       const requestOptions = {
         method: 'POST',
         headers,
-        body,
+        body: JSON.stringify(body),
       };
 
       fetch('https://www.adobe.com/api2/subscribe_v1', requestOptions)


### PR DESCRIPTION
JSON body needs to be stringified for signup form.

Wasn't able to see this bug until I could publish because of CORS.

Test URL: https://submit-email-block--express-website--adobe.hlx3.page/express/campaigns/adbemeta-dev?lighthouse=on