### PR TITLE
feat: use blue facebook logo inside banner

### DIFF
--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -532,6 +532,10 @@ main .columns .icon.icon-cc-express-stacked {
   height: unset;
 }
 
+main .banner .icon.icon-facebook {
+  fill: #1877f2;
+}
+
 main .hero .hero-bg {
     position: absolute;
     top: 0;


### PR DESCRIPTION
https://main--express-website--adobe.hlx3.page/drafts/nipun/registration#discover-more-tips-on-facebook
vs
https://fb-logo--express-website--adobe.hlx3.page/drafts/nipun/registration?lighthouse=on#discover-more-tips-on-facebook