### PR TITLE
chore: smaller top margin for steps container

### DIFF
--- a/express/blocks/steps/steps.css
+++ b/express/blocks/steps/steps.css
@@ -55,7 +55,7 @@ main .steps .step-description {
 main .section-wrapper.steps-dark-container,
 main .section-wrapper.steps-highlight-container,
 main .section-wrapper.steps-container {
-  margin-top: 110px;
+  margin-top: 80px;
 }
 
 main .section-wrapper.steps-dark-container,


### PR DESCRIPTION
smaller top margin for highlight steps as requested by @skelleyadobe 

https://main--express-website--adobe.hlx3.page/drafts/rassingh/edit/resize
vs
https://steps-top-margin--express-website--adobe.hlx3.page/drafts/rassingh/edit/resize?lighthouse=on