### PR TITLE
Issue #330: beginPurchaseFlow event is missing

### DIFF
--- a/express/blocks/pricing-columns/pricing-columns.js
+++ b/express/blocks/pricing-columns/pricing-columns.js
@@ -87,10 +87,7 @@ export function buildUrl(optionUrl, country, language) {
   return planUrl.href;
 }
 
-function dropdownAnalytics(plan) {
-  const adobeEventName = 'adobe.com:express:pricing:commitmentType:selected';
-  const sparkEventName = 'pricing:commitmentTypeSelected';
-
+function pushPricingAnalytics(adobeEventName, sparkEventName, plan) {
   digitalData._set('primaryEvent.eventInfo.eventName', adobeEventName);
   digitalData._set('spark.eventData.eventName', sparkEventName);
   digitalData._set('spark.eventData.contextualData4', `billingFrequency:${plan.frequency}`);
@@ -141,10 +138,9 @@ function decorateIconList($column) {
   if ($iconList.children.length > 0) $column.appendChild($iconList);
 }
 
-async function selectPlan($pricingHeader, planUrl, sendAnalyticEvent) {
+async function fetchPlan(planUrl) {
   const link = new URL(planUrl);
   const params = link.searchParams;
-  let buttonId;
 
   const plan = {
     url: planUrl,
@@ -159,12 +155,12 @@ async function selectPlan($pricingHeader, planUrl, sendAnalyticEvent) {
     plan.offerId = 'FREE0';
     plan.frequency = 'monthly';
     plan.name = 'Free';
-    buttonId = 'free-trial';
+    plan.stringId = 'free-trial';
   } else {
     plan.offerId = params.get('items[0][id]');
     plan.frequency = null;
     plan.name = 'Premium';
-    buttonId = '3-month-trial';
+    plan.stringId = '3-month-trial';
   }
 
   if (plan.offerId === '70C6FDFC57461D5E449597CC8F327CF1') {
@@ -189,14 +185,23 @@ async function selectPlan($pricingHeader, planUrl, sendAnalyticEvent) {
     plan.formatted = plan.formatted.replace(plan.rawPrice[0], `<strong>${plan.rawPrice[0]}</strong>`);
   }
 
+  return plan;
+}
+
+async function selectPlan($pricingHeader, planUrl, sendAnalyticEvent) {
+  const plan = await fetchPlan(planUrl);
+
   $pricingHeader.querySelector('.pricing-columns-price').innerHTML = plan.formatted;
   $pricingHeader.querySelector('.pricing-columns-price').classList.add(plan.currency.toLowerCase());
   $pricingHeader.querySelector('.pricing-columns-cta').href = buildUrl(plan.url, plan.country, plan.language);
-  $pricingHeader.querySelector('.pricing-columns-cta').id = buttonId;
+  $pricingHeader.querySelector('.pricing-columns-cta').dataset.planUrl = planUrl;
+  $pricingHeader.querySelector('.pricing-columns-cta').id = plan.stringId;
   $pricingHeader.querySelector('.pricing-columns-vat-info').innerHTML = plan.vatInfo || '';
 
   if (sendAnalyticEvent) {
-    dropdownAnalytics(plan);
+    const adobeEventName = 'adobe.com:express:pricing:commitmentType:selected';
+    const sparkEventName = 'pricing:commitmentTypeSelected';
+    pushPricingAnalytics(adobeEventName, sparkEventName, plan);
   }
 }
 
@@ -254,6 +259,13 @@ function decoratePlan($column) {
     const $pricingCta = createTag('a', { class: 'pricing-columns-cta button large' });
     $pricingCta.innerHTML = $elements[2].textContent;
     $pricingCta.href = plans[0].url;
+    $pricingCta.addEventListener('click', async () => {
+      const { planUrl } = $pricingCta.dataset;
+      const plan = await fetchPlan(planUrl);
+      const adobeEventName = 'adobe.com:express:pricing:beginPurchaseFlow';
+      const sparkEventName = 'pricing:beginPurchaseFlow';
+      pushPricingAnalytics(adobeEventName, sparkEventName, plan);
+    });
     $pricingHeader.append($pricingCta);
 
     selectPlan($pricingHeader, plans[0].url, false);

--- a/express/blocks/pricing-columns/pricing-columns.js
+++ b/express/blocks/pricing-columns/pricing-columns.js
@@ -88,6 +88,9 @@ export function buildUrl(optionUrl, country, language) {
 }
 
 function pushPricingAnalytics(adobeEventName, sparkEventName, plan) {
+  const url = new URL(window.location.href);
+  const sparkTouchpoint = url.searchParams.get('touchpointName');
+
   digitalData._set('primaryEvent.eventInfo.eventName', adobeEventName);
   digitalData._set('spark.eventData.eventName', sparkEventName);
   digitalData._set('spark.eventData.contextualData4', `billingFrequency:${plan.frequency}`);
@@ -97,6 +100,7 @@ function pushPricingAnalytics(adobeEventName, sparkEventName, plan) {
   digitalData._set('spark.eventData.contextualData10', `price:${plan.price}`);
   digitalData._set('spark.eventData.contextualData12', `productName:${plan.name} - ${plan.frequency}`);
   digitalData._set('spark.eventData.contextualData14', 'quantity:1');
+  digitalData._set('spark.eventData.trigger', sparkTouchpoint);
 
   _satellite.track('event', {
     digitalData: digitalData._snapshot(),
@@ -263,7 +267,7 @@ function decoratePlan($column) {
       const { planUrl } = $pricingCta.dataset;
       const plan = await fetchPlan(planUrl);
       const adobeEventName = 'adobe.com:express:pricing:beginPurchaseFlow';
-      const sparkEventName = 'pricing:beginPurchaseFlow';
+      const sparkEventName = 'beginPurchaseFlow';
       pushPricingAnalytics(adobeEventName, sparkEventName, plan);
     });
     $pricingHeader.append($pricingCta);

--- a/express/blocks/pricing-columns/pricing-columns.js
+++ b/express/blocks/pricing-columns/pricing-columns.js
@@ -163,9 +163,9 @@ async function fetchPlan(planUrl) {
     plan.stringId = '3-month-trial';
   }
 
-  if (plan.offerId === '70C6FDFC57461D5E449597CC8F327CF1') {
+  if (plan.offerId === '70C6FDFC57461D5E449597CC8F327CF1' || plan.offerId === 'CFB1B7F391F77D02FE858C43C4A5C64F') {
     plan.frequency = 'Monthly';
-  } else if (plan.offerId === 'E963185C442F0C5EEB3AE4F4AAB52C24') {
+  } else if (plan.offerId === 'E963185C442F0C5EEB3AE4F4AAB52C24' || plan.offerId === 'BADDACAB87D148A48539B303F3C5FA92') {
     plan.frequency = 'Annual';
   } else {
     plan.frequency = null;


### PR DESCRIPTION
This branch was created for the purpose of resolving this issue:
https://github.com/adobe/express-website-issues/issues/330

You can find a test url here:
https://330-beginpurchaseflow--express-website--webistry-development.hlx3.page/express/pricing

I have concerns about launching an async event on submit since I have a feeling in some cases the page will transfer before the function gets to finish, but I am not sure how else to go about it without rewriting most of the code and saving plans locally to avoid fetching them multiple times.