### PR TITLE
Japanese balanced word wrap

### DIFF
--- a/express/scripts/bw2.js
+++ b/express/scripts/bw2.js
@@ -9,6 +9,10 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+/*
+ * Japanese balanced word wrap logic
+ */
+
 const canvas = document.createElement('canvas');
 const context = canvas.getContext('2d');
 

--- a/express/scripts/bw2.js
+++ b/express/scripts/bw2.js
@@ -85,7 +85,8 @@ function insertAllLevelLineBreak(text = '', seps = [], maxLevel = 5, ratio = 1.0
   for (let l = 1; l <= maxLevel; l += 1) {
     const step = Math.ceil(text.length / (l + 1));
     const firstPos = Math.ceil(step * ratio);
-    const fbpos = getNearestWrappingPoint(text, seps, firstPos, false);
+    const bidirect = (ratio <= 1.0);
+    const fbpos = getNearestWrappingPoint(text, seps, firstPos, bidirect);
     if (fbpos >= 0 && fbpos < text.length) {
       poses[fbpos] = poses[fbpos] || [];
       if (poses[fbpos].indexOf(l) < 0) {

--- a/express/scripts/bw2.js
+++ b/express/scripts/bw2.js
@@ -150,11 +150,17 @@ function toggleWBR(div = document.body, text = '', poses = [], maxLevel = 5) {
       return;
     }
     let cl = 0;
-    while (cl < minWidths.length - 1 && minWidths[cl] > w) {
+    while (cl < minWidths.length && minWidths[cl] > w) {
       cl += 1;
     }
-    div.querySelectorAll(`wbr.jpn-balanced-wbr-l${cl}`).forEach((e) => e.classList.remove('wbr-off'));
-    div.querySelectorAll(`wbr:not(.jpn-balanced-wbr-l${cl})`).forEach((e) => e.classList.add('wbr-off'));
+    if (cl < minWidths.length) {
+      div.querySelectorAll(`wbr.jpn-balanced-wbr-l${cl}`).forEach((e) => e.classList.remove('wbr-off'));
+      div.querySelectorAll(`wbr:not(.jpn-balanced-wbr-l${cl})`).forEach((e) => e.classList.add('wbr-off'));
+    } else {
+      // Lengths of lines exceed container's width event at maximum number of line wraps.
+      // Enable all WBR tags as a last resort
+      div.querySelectorAll('wbr').forEach((e) => e.classList.remove('wbr-off'));
+    }
   });
 
   resizeObserver.observe(div);

--- a/express/scripts/bw2.js
+++ b/express/scripts/bw2.js
@@ -10,173 +10,166 @@
  * governing permissions and limitations under the License.
  */
 const canvas = document.createElement('canvas');
-const context = canvas.getContext("2d");
+const context = canvas.getContext('2d');
 
 function getTextWidth(text, font) {
-    context.font = font;
-    const metrics = context.measureText(text);
-    return metrics.width;
-};
-
+  context.font = font;
+  const metrics = context.measureText(text);
+  return metrics.width;
+}
 
 function getCssStyle(element, prop) {
-    return window.getComputedStyle(element).getPropertyValue(prop);
+  return window.getComputedStyle(element).getPropertyValue(prop);
 }
 
 function getCanvasFontSize(el = document.body) {
-    const fontWeight = getCssStyle(el, 'font-weight') || 'normal';
-    const fontSize = getCssStyle(el, 'font-size') || '16px';
-    const fontFamily = getCssStyle(el, 'font-family') || 'Times New Roman';
+  const fontWeight = getCssStyle(el, 'font-weight') || 'normal';
+  const fontSize = getCssStyle(el, 'font-size') || '16px';
+  const fontFamily = getCssStyle(el, 'font-family') || 'Times New Roman';
 
-    return `${fontWeight} ${fontSize} ${fontFamily}`;
-}
-
-export class BalancedWordWrapper {
-    constructor (maxLineNum = 5, ratio = 1.0) {
-        this.maxLevel = maxLineNum;
-        this.ratio = ratio;
-    }
-
-    applyElement = function (el = document.body, ratio = this.ratio) {
-        const oriText = el.innerHTML;
-        if (oriText.indexOf('<wbr>') < 0) {
-            return;
-        }
-        const { text, seps } = separateTextAndDelimiter(oriText);
-        const {newText, poses} = insertAllLevelLineBreak(text, seps, this.maxLevel, ratio);
-        el.innerHTML = newText;
-        toggleWBR(el, text, poses, this.maxLevel);
-    }
+  return `${fontWeight} ${fontSize} ${fontFamily}`;
 }
 
 function separateTextAndDelimiter(text) {
-    // replace <wbr> tag with | in original text
-    text = text.split('<wbr>').join('|');
-    const newText = [];
-    const seps = [];
-    for (let i = 0; i < text.length; ++i) {
-        if (text[i] === '|') {
-            seps.pop();
-            seps.push(1);
-        } else {
-            seps.push(0);
-            newText.push(text[i]);
-        }
+  // replace <wbr> tag with | in original text
+  const pipedText = text.split('<wbr>').join('|');
+  const newText = [];
+  const seps = [];
+  for (let i = 0; i < pipedText.length; i += 1) {
+    if (pipedText[i] === '|') {
+      seps.pop();
+      seps.push(1);
+    } else {
+      seps.push(0);
+      newText.push(pipedText[i]);
     }
-    return {text: newText.join(''), seps};
+  }
+  return { text: newText.join(''), seps };
 }
 
 function getNearestWrappingPoint(text = '', seps = [], pos = 0, bidirectional = true) {
-    if (seps[pos] === 1) {
-        return pos;
+  if (seps[pos] === 1) {
+    return pos;
+  }
+  let i = 1;
+  for (; pos - i >= 0 && pos + i < text.length; i += 1) {
+    if (bidirectional && seps[pos - i] === 1) {
+      return pos - i;
     }
-    let i = 1;
-    for (; pos - i >= 0 && pos + i < text.length; ++i) {
-        if (bidirectional && seps[pos - i] === 1) {
-            return pos - i;
-        }
-        if (seps[pos + i] === 1) {
-            return pos + i;
-        }
+    if (seps[pos + i] === 1) {
+      return pos + i;
     }
-    while (bidirectional && pos - i >= 0) {
-        if (seps[pos - i] === 1) {
-            return pos - i;
-        }
-        ++i;
+  }
+  while (bidirectional && pos - i >= 0) {
+    if (seps[pos - i] === 1) {
+      return pos - i;
     }
-    while (pos + i < text.length) {
-        if (seps[pos + i] === 1) {
-            return pos + i;
-        }
-        ++i;
+    i += 1;
+  }
+  while (pos + i < text.length) {
+    if (seps[pos + i] === 1) {
+      return pos + i;
     }
-    return -1;
+    i += 1;
+  }
+  return -1;
 }
 
 function insertAllLevelLineBreak(text = '', seps = [], maxLevel = 5, ratio = 1.0) {
-    let newText = '';
-    const poses = Array(text.length);
-    for (let l = 1; l <= maxLevel; ++l) {
-        const step = Math.ceil(text.length / (l + 1));
-        const firstPos = Math.ceil(step * ratio);
-        const bpos = getNearestWrappingPoint(text, seps, firstPos, false);
-        if (bpos < 0 || bpos >= text.length) {
-            continue;
-        }
+  let newText = '';
+  const poses = Array(text.length);
+  for (let l = 1; l <= maxLevel; l += 1) {
+    const step = Math.ceil(text.length / (l + 1));
+    const firstPos = Math.ceil(step * ratio);
+    const fbpos = getNearestWrappingPoint(text, seps, firstPos, false);
+    if (fbpos >= 0 && fbpos < text.length) {
+      poses[fbpos] = poses[fbpos] || [];
+      if (poses[fbpos].indexOf(l) < 0) {
+        poses[fbpos].push(l);
+      }
+    }
+
+    for (let pos = Math.max(firstPos, step) + step; pos < text.length; pos += step) {
+      const bpos = getNearestWrappingPoint(text, seps, pos);
+      if (bpos >= 0 && bpos < text.length) {
         poses[bpos] = poses[bpos] || [];
         if (poses[bpos].indexOf(l) < 0) {
-            poses[bpos].push(l);
+          poses[bpos].push(l);
         }
- 
-        for (let pos =  Math.max(firstPos, step) + step; pos < text.length; pos += step) {
-            const bpos = getNearestWrappingPoint(text, seps, pos);
-            if (bpos < 0 || bpos >= text.length) {
-                continue;
-            }
-            // if (poses[bpos] > 0) {
-            //     continue;
-            // }
-            poses[bpos] = poses[bpos] || [];
-            if (poses[bpos].indexOf(l) < 0) {
-                poses[bpos].push(l);
-            }
-        }
+      }
     }
-    for (let i = 0; i < text.length; ++i) {
-        newText += text[i];
-        if (seps[i] === 1) {
-            if (!poses[i]) {
-                // wbr tag was originally inserted here, but it's not used for bw2.
-                // Keep the original wbr in result text.
-                newText += '<wbr />';
-                continue;
-            }
-            const posStr = poses[i].map(v => `jpn-balanced-wbr-l${v}`);
-            const classNames = posStr.join(' ');
-            if (poses[i].length > 0) {
-                newText += `<wbr class="${classNames}" />`;
-            }
+  }
+  for (let i = 0; i < text.length; i += 1) {
+    newText += text[i];
+    if (seps[i] === 1) {
+      if (!poses[i]) {
+        // wbr tag was originally inserted here, but it's not used for bw2.
+        // Keep the original wbr in result text.
+        newText += '<wbr>';
+      } else {
+        const posStr = poses[i].map((v) => `jpn-balanced-wbr-l${v}`);
+        const classNames = posStr.join(' ');
+        if (poses[i].length > 0) {
+          newText += `<wbr class="${classNames}">`;
         }
+      }
     }
-    return { newText, poses };
+  }
+  return { newText, poses };
 }
 
 function toggleWBR(div = document.body, text = '', poses = [], maxLevel = 5) {
-    const minWidths = Array(maxLevel + 1);
-    minWidths[0] = getTextWidth(text, getCanvasFontSize(div));
-    for (let l = 1; l <= maxLevel; ++l) {
-        const levelPoses = [];
-        poses.forEach((p, i) => {
-            if (p && p.indexOf(l) >= 0) {
-                levelPoses.push(i);
-            }
-        });
-        levelPoses.sort();
-        const lengths = [];
-        let prev = 0;
-        for (let bpos of levelPoses) {
-            lengths.push(getTextWidth(text.substring(prev, bpos + 1), getCanvasFontSize(div)));
-            prev = bpos + 1;
-        }
-        lengths.push(getTextWidth(text.substring(prev, text.length), getCanvasFontSize(div)));
-        minWidths[l] = Math.max(...lengths);
-    }
-
-    const resizeObserver = new ResizeObserver(entries => {
-        const w = entries[0].contentRect.width;
-        // console.log(w);
-        if (w >= minWidths[0]) {
-            return;
-        }
-        let cl = 0;
-        while (cl < minWidths.length - 1 && minWidths[cl] > w) {
-            ++cl;
-        }
-        div.querySelectorAll(`.jpn-balanced-wbr-l${cl}`).forEach(e => e.classList.remove('wbr-off'));
-        div.querySelectorAll(`:not(.jpn-balanced-wbr-l${cl})`).forEach(e => e.classList.add('wbr-off'));
+  const minWidths = Array(maxLevel + 1);
+  minWidths[0] = getTextWidth(text, getCanvasFontSize(div));
+  for (let l = 1; l <= maxLevel; l += 1) {
+    const levelPoses = [];
+    poses.forEach((p, i) => {
+      if (p && p.indexOf(l) >= 0) {
+        levelPoses.push(i);
+      }
     });
-    
-    resizeObserver.observe(div);
+    levelPoses.sort();
+    const lengths = [];
+    let prev = 0;
+    for (const bpos of levelPoses) {
+      lengths.push(getTextWidth(text.substring(prev, bpos + 1), getCanvasFontSize(div)));
+      prev = bpos + 1;
+    }
+    lengths.push(getTextWidth(text.substring(prev, text.length), getCanvasFontSize(div)));
+    minWidths[l] = Math.max(...lengths);
+  }
 
+  const resizeObserver = new ResizeObserver((entries) => {
+    const w = entries[0].contentRect.width;
+    // console.log(w);
+    if (w >= minWidths[0]) {
+      return;
+    }
+    let cl = 0;
+    while (cl < minWidths.length - 1 && minWidths[cl] > w) {
+      cl += 1;
+    }
+    div.querySelectorAll(`.jpn-balanced-wbr-l${cl}`).forEach((e) => e.classList.remove('wbr-off'));
+    div.querySelectorAll(`:not(.jpn-balanced-wbr-l${cl})`).forEach((e) => e.classList.add('wbr-off'));
+  });
+
+  resizeObserver.observe(div);
+}
+
+export default class BalancedWordWrapper {
+  constructor(maxLineNum = 5, ratio = 1.0) {
+    this.maxLevel = maxLineNum;
+    this.ratio = ratio;
+  }
+
+  applyElement = (el = document.body, ratio = this.ratio) => {
+    const oriText = el.innerHTML;
+    if (oriText.indexOf('<wbr>') < 0) {
+      return;
+    }
+    const { text, seps } = separateTextAndDelimiter(oriText);
+    const { newText, poses } = insertAllLevelLineBreak(text, seps, this.maxLevel, ratio);
+    el.innerHTML = newText;
+    toggleWBR(el, text, poses, this.maxLevel);
+  }
 }

--- a/express/scripts/bw2.js
+++ b/express/scripts/bw2.js
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const canvas = document.createElement('canvas');
+const context = canvas.getContext("2d");
+
+function getTextWidth(text, font) {
+    context.font = font;
+    const metrics = context.measureText(text);
+    return metrics.width;
+};
+
+
+function getCssStyle(element, prop) {
+    return window.getComputedStyle(element).getPropertyValue(prop);
+}
+
+function getCanvasFontSize(el = document.body) {
+    const fontWeight = getCssStyle(el, 'font-weight') || 'normal';
+    const fontSize = getCssStyle(el, 'font-size') || '16px';
+    const fontFamily = getCssStyle(el, 'font-family') || 'Times New Roman';
+
+    return `${fontWeight} ${fontSize} ${fontFamily}`;
+}
+
+export class BalancedWordWrapper {
+    constructor (maxLineNum = 5, ratio = 1.0) {
+        this.maxLevel = maxLineNum;
+        this.ratio = ratio;
+    }
+
+    applyElement = function (el = document.body, ratio = this.ratio) {
+        const oriText = el.innerHTML;
+        if (oriText.indexOf('<wbr>') < 0) {
+            return;
+        }
+        const { text, seps } = separateTextAndDelimiter(oriText);
+        const {newText, poses} = insertAllLevelLineBreak(text, seps, this.maxLevel, ratio);
+        el.innerHTML = newText;
+        toggleWBR(el, text, poses, this.maxLevel);
+    }
+}
+
+function separateTextAndDelimiter(text) {
+    // replace <wbr> tag with | in original text
+    text = text.split('<wbr>').join('|');
+    const newText = [];
+    const seps = [];
+    for (let i = 0; i < text.length; ++i) {
+        if (text[i] === '|') {
+            seps.pop();
+            seps.push(1);
+        } else {
+            seps.push(0);
+            newText.push(text[i]);
+        }
+    }
+    return {text: newText.join(''), seps};
+}
+
+function getNearestWrappingPoint(text = '', seps = [], pos = 0, bidirectional = true) {
+    if (seps[pos] === 1) {
+        return pos;
+    }
+    let i = 1;
+    for (; pos - i >= 0 && pos + i < text.length; ++i) {
+        if (bidirectional && seps[pos - i] === 1) {
+            return pos - i;
+        }
+        if (seps[pos + i] === 1) {
+            return pos + i;
+        }
+    }
+    while (bidirectional && pos - i >= 0) {
+        if (seps[pos - i] === 1) {
+            return pos - i;
+        }
+        ++i;
+    }
+    while (pos + i < text.length) {
+        if (seps[pos + i] === 1) {
+            return pos + i;
+        }
+        ++i;
+    }
+    return -1;
+}
+
+function insertAllLevelLineBreak(text = '', seps = [], maxLevel = 5, ratio = 1.0) {
+    let newText = '';
+    const poses = Array(text.length);
+    for (let l = 1; l <= maxLevel; ++l) {
+        const step = Math.ceil(text.length / (l + 1));
+        const firstPos = Math.ceil(step * ratio);
+        const bpos = getNearestWrappingPoint(text, seps, firstPos, false);
+        if (bpos < 0 || bpos >= text.length) {
+            continue;
+        }
+        poses[bpos] = poses[bpos] || [];
+        if (poses[bpos].indexOf(l) < 0) {
+            poses[bpos].push(l);
+        }
+ 
+        for (let pos =  Math.max(firstPos, step) + step; pos < text.length; pos += step) {
+            const bpos = getNearestWrappingPoint(text, seps, pos);
+            if (bpos < 0 || bpos >= text.length) {
+                continue;
+            }
+            // if (poses[bpos] > 0) {
+            //     continue;
+            // }
+            poses[bpos] = poses[bpos] || [];
+            if (poses[bpos].indexOf(l) < 0) {
+                poses[bpos].push(l);
+            }
+        }
+    }
+    for (let i = 0; i < text.length; ++i) {
+        newText += text[i];
+        if (seps[i] === 1) {
+            if (!poses[i]) {
+                // wbr tag was originally inserted here, but it's not used for bw2.
+                // Keep the original wbr in result text.
+                newText += '<wbr />';
+                continue;
+            }
+            const posStr = poses[i].map(v => `jpn-balanced-wbr-l${v}`);
+            const classNames = posStr.join(' ');
+            if (poses[i].length > 0) {
+                newText += `<wbr class="${classNames}" />`;
+            }
+        }
+    }
+    return { newText, poses };
+}
+
+function toggleWBR(div = document.body, text = '', poses = [], maxLevel = 5) {
+    const minWidths = Array(maxLevel + 1);
+    minWidths[0] = getTextWidth(text, getCanvasFontSize(div));
+    for (let l = 1; l <= maxLevel; ++l) {
+        const levelPoses = [];
+        poses.forEach((p, i) => {
+            if (p && p.indexOf(l) >= 0) {
+                levelPoses.push(i);
+            }
+        });
+        levelPoses.sort();
+        const lengths = [];
+        let prev = 0;
+        for (let bpos of levelPoses) {
+            lengths.push(getTextWidth(text.substring(prev, bpos + 1), getCanvasFontSize(div)));
+            prev = bpos + 1;
+        }
+        lengths.push(getTextWidth(text.substring(prev, text.length), getCanvasFontSize(div)));
+        minWidths[l] = Math.max(...lengths);
+    }
+
+    const resizeObserver = new ResizeObserver(entries => {
+        const w = entries[0].contentRect.width;
+        // console.log(w);
+        if (w >= minWidths[0]) {
+            return;
+        }
+        let cl = 0;
+        while (cl < minWidths.length - 1 && minWidths[cl] > w) {
+            ++cl;
+        }
+        div.querySelectorAll(`.jpn-balanced-wbr-l${cl}`).forEach(e => e.classList.remove('wbr-off'));
+        div.querySelectorAll(`:not(.jpn-balanced-wbr-l${cl})`).forEach(e => e.classList.add('wbr-off'));
+    });
+    
+    resizeObserver.observe(div);
+
+}

--- a/express/scripts/bw2.js
+++ b/express/scripts/bw2.js
@@ -153,8 +153,8 @@ function toggleWBR(div = document.body, text = '', poses = [], maxLevel = 5) {
     while (cl < minWidths.length - 1 && minWidths[cl] > w) {
       cl += 1;
     }
-    div.querySelectorAll(`.jpn-balanced-wbr-l${cl}`).forEach((e) => e.classList.remove('wbr-off'));
-    div.querySelectorAll(`:not(.jpn-balanced-wbr-l${cl})`).forEach((e) => e.classList.add('wbr-off'));
+    div.querySelectorAll(`wbr.jpn-balanced-wbr-l${cl}`).forEach((e) => e.classList.remove('wbr-off'));
+    div.querySelectorAll(`wbr:not(.jpn-balanced-wbr-l${cl})`).forEach((e) => e.classList.add('wbr-off'));
   });
 
   resizeObserver.observe(div);

--- a/express/scripts/bw2.js
+++ b/express/scripts/bw2.js
@@ -191,7 +191,24 @@ export default class BalancedWordWrapper {
   }
 
   applyElement = (el = document.body, ratio = this.ratio) => {
-    const oriText = el.innerHTML;
+    const children = el.childNodes;
+    let oriText = '';
+    let hasChildElement = false;
+    children.forEach((node) => {
+      if (node.nodeType === Node.ELEMENT_NODE && node.nodeName !== 'WBR') {
+        hasChildElement = true;
+        this.applyElement(node, ratio);
+      } else if (node.nodeType === Node.TEXT_NODE) {
+        oriText += node.textContent;
+      } else if (node.nodeName === 'WBR') {
+        oriText += '<wbr>';
+      }
+    });
+    if (hasChildElement) {
+      // current element has child elements, which have been handled recursively,
+      // do nothing but return
+      return;
+    }
     const { text, seps } = separateTextAndDelimiter(oriText);
     const { widthsFromStart } = getChunkWidths(el, text, seps);
     const { newText, poses } = insertAllLevelLineBreak(

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1523,8 +1523,14 @@ async function wordBreakJapanese() {
   }
   const { loadDefaultJapaneseParser } = await import('./budoux-index-ja.min.js');
   const parser = loadDefaultJapaneseParser();
+  const { BalancedWordWrapper } = await import('./bw2.js');
+  const bw2 = new BalancedWordWrapper();
   document.querySelectorAll('h1, h2, h3, h4, h5, p:not(.button-container)').forEach((el) => {
     parser.applyElement(el);
+    if (el.tagName !== 'P') {
+      // apply balanced word wrap to headings
+      bw2.applyElement(el);
+    }
   });
 }
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1523,15 +1523,18 @@ async function wordBreakJapanese() {
   }
   const { loadDefaultJapaneseParser } = await import('./budoux-index-ja.min.js');
   const parser = loadDefaultJapaneseParser();
-  const BalancedWordWrapper = (await import('./bw2.js')).default;
-  const bw2 = new BalancedWordWrapper();
   document.querySelectorAll('h1, h2, h3, h4, h5, p:not(.button-container)').forEach((el) => {
     parser.applyElement(el);
-    if (el.tagName !== 'P') {
+  });
+
+  window.setTimeout(async () => {
+    const BalancedWordWrapper = (await import('./bw2.js')).default;
+    const bw2 = new BalancedWordWrapper();
+    document.querySelectorAll('h1, h2, h3, h4, h5').forEach((el) => {
       // apply balanced word wrap to headings
       bw2.applyElement(el);
-    }
-  });
+    });
+  }, 1000);
 }
 
 /**

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1527,14 +1527,20 @@ async function wordBreakJapanese() {
     parser.applyElement(el);
   });
 
-  window.setTimeout(async () => {
-    const BalancedWordWrapper = (await import('./bw2.js')).default;
-    const bw2 = new BalancedWordWrapper();
-    document.querySelectorAll('h1, h2, h3, h4, h5').forEach((el) => {
-      // apply balanced word wrap to headings
-      bw2.applyElement(el);
-    });
-  }, 1000);
+  const BalancedWordWrapper = (await import('./bw2.js')).default;
+  const bw2 = new BalancedWordWrapper();
+  document.querySelectorAll('h1, h2, h3, h4, h5').forEach((el) => {
+    // apply balanced word wrap to headings
+    if (window.requestIdleCallback) {
+      window.requestIdleCallback(() => {
+        bw2.applyElement(el);
+      });
+    } else {
+      window.setTimeout(() => {
+        bw2.applyElement(el);
+      }, 1000);
+    }
+  });
 }
 
 /**

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1523,7 +1523,7 @@ async function wordBreakJapanese() {
   }
   const { loadDefaultJapaneseParser } = await import('./budoux-index-ja.min.js');
   const parser = loadDefaultJapaneseParser();
-  const { BalancedWordWrapper } = await import('./bw2.js');
+  const BalancedWordWrapper = (await import('./bw2.js')).default;
   const bw2 = new BalancedWordWrapper();
   document.querySelectorAll('h1, h2, h3, h4, h5, p:not(.button-container)').forEach((el) => {
     parser.applyElement(el);

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1531,7 +1531,7 @@ async function wordBreakJapanese() {
   const bw2 = new BalancedWordWrapper();
   document.querySelectorAll('h1, h2, h3, h4, h5').forEach((el) => {
     // apply balanced word wrap to headings
-    if (window.requestIdleCallback) {
+    if (typeof window.requestIdleCallback === 'function') {
       window.requestIdleCallback(() => {
         bw2.applyElement(el);
       });

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -768,3 +768,8 @@ img.icon-apple-store, img.icon-google-store, img.icon-galaxy-store, img.icon-mic
   width: 32px;
   height: 32px;
 }
+
+/* Japanese heading balanced word wrap styles */
+.wbr-off {
+  display: none;
+}

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -770,6 +770,6 @@ img.icon-apple-store, img.icon-google-store, img.icon-galaxy-store, img.icon-mic
 }
 
 /* Japanese heading balanced word wrap styles */
-.wbr-off {
+wbr.wbr-off {
   display: none;
 }

--- a/test/unit/bw2.test.js
+++ b/test/unit/bw2.test.js
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* global expect */
+/* eslint-env mocha */
+
+import {
+  createTag,
+} from '../../express/scripts/scripts.js';
+import BalancedWordWrapper from '../../express/scripts/bw2.js';
+
+describe('Japanese balanced word wrap', () => {
+  describe('BalancedWordWrapper', () => {
+    const validate = (target = document.body, expects = []) => {
+      const children = target.childNodes;
+      expect(children.length).to.equal(expects.length, 'number of child nodes mismatch');
+      for (const [i, c] of children.entries()) {
+        const e = expects[i];
+        if (typeof e === 'string') {
+          expect(c.nodeType).to.equal(Node.TEXT_NODE);
+          expect(c.textContent).to.equal(e);
+        } else {
+          expect(c.nodeType).to.equal(Node.ELEMENT_NODE);
+          expect(c.nodeName.toLowerCase()).to.equal(e.nodeName.toLowerCase());
+          if (e.classList) {
+            expect(Array.from(c.classList)).to.have.members(e.classList.map((v) => `jpn-balanced-wbr-l${v}`));
+          }
+        }
+      }
+    };
+
+    it('should insert proper class names to WBR tags', () => {
+      let bw2 = new BalancedWordWrapper();
+      const t1 = createTag('h1');
+      t1.innerHTML = 'aaa<wbr>bbb';
+      bw2.applyElement(t1);
+      validate(t1, [
+        'aaa',
+        { nodeName: 'wbr', classList: [1, 2, 3, 4, 5] },
+        'bbb',
+      ]);
+      bw2 = new BalancedWordWrapper(2);
+      t1.innerHTML = 'aaa<wbr>bbb<wbr>ccc';
+      bw2.applyElement(t1);
+      validate(t1, [
+        'aaa',
+        { nodeName: 'wbr', classList: [1, 2] },
+        'bbb',
+        { nodeName: 'wbr', classList: [2] },
+        'ccc',
+      ]);
+      t1.innerHTML = 'aaa<wbr>bbbb<wbr>ccc';
+      bw2.applyElement(t1);
+      validate(t1, [
+        'aaa',
+        { nodeName: 'wbr', classList: [1, 2] },
+        'bbbb',
+        { nodeName: 'wbr', classList: [2] },
+        'ccc',
+      ]);
+      t1.innerHTML = 'aa<wbr>bbbb<wbr>ccc';
+      bw2.applyElement(t1);
+      validate(t1, [
+        'aa',
+        { nodeName: 'wbr', classList: [2] },
+        'bbbb',
+        { nodeName: 'wbr', classList: [1, 2] },
+        'ccc',
+      ]);
+      t1.innerHTML = 'aaa<wbr>bbb<wbr>ccc<wbr>ddd<wbr>eee<wbr>fff';
+      bw2 = new BalancedWordWrapper();
+      bw2.applyElement(t1);
+      validate(t1, [
+        'aaa',
+        { nodeName: 'wbr', classList: [3, 4, 5] },
+        'bbb',
+        { nodeName: 'wbr', classList: [2, 5] },
+        'ccc',
+        { nodeName: 'wbr', classList: [1, 3, 4, 5] },
+        'ddd',
+        { nodeName: 'wbr', classList: [2, 4, 5] },
+        'eee',
+        { nodeName: 'wbr', classList: [3, 4, 5] },
+        'fff',
+      ]);
+    });
+
+    it('should replace alternative separators with WBR tags', () => {
+      const bw2 = new BalancedWordWrapper();
+      const t1 = createTag('h1');
+      t1.innerHTML = 'aaa\uff3fbbb';
+      bw2.applyElement(t1);
+      validate(t1, [
+        'aaa', { nodeName: 'wbr' }, 'bbb',
+      ]);
+      t1.innerHTML = 'aaa\uff3f\uff3fbbb';
+      bw2.applyElement(t1);
+      validate(t1, [
+        'aaa', { nodeName: 'wbr' }, 'bbb',
+      ]);
+      t1.innerHTML = 'aaa\uff3f<wbr>bbb';
+      bw2.applyElement(t1);
+      validate(t1, [
+        'aaa', { nodeName: 'wbr' }, 'bbb',
+      ]);
+      t1.innerHTML = 'aaa\uff3fbbb<wbr>ccc';
+      bw2.applyElement(t1);
+      validate(t1, [
+        'aaa', { nodeName: 'wbr' }, 'bbb', { nodeName: 'wbr' }, 'ccc',
+      ]);
+      t1.innerHTML = 'aaa\uff3fbbb\uff3f<wbr>ccc';
+      bw2.applyElement(t1);
+      validate(t1, [
+        'aaa', { nodeName: 'wbr' }, 'bbb', { nodeName: 'wbr' }, 'ccc',
+      ]);
+      t1.innerHTML = 'aaa\uff3fbbb\uff3fccc';
+      bw2.applyElement(t1);
+      validate(t1, [
+        'aaa', { nodeName: 'wbr' }, 'bbb', { nodeName: 'wbr' }, 'ccc',
+      ]);
+    });
+  });
+});

--- a/test/unit/bw2.test.js
+++ b/test/unit/bw2.test.js
@@ -48,24 +48,6 @@ describe('Japanese balanced word wrap', () => {
         'bbb',
       ]);
       bw2 = new BalancedWordWrapper(2);
-      t1.innerHTML = 'aaa<wbr>bbb<wbr>ccc';
-      bw2.applyElement(t1);
-      validate(t1, [
-        'aaa',
-        { nodeName: 'wbr', classList: [1, 2] },
-        'bbb',
-        { nodeName: 'wbr', classList: [2] },
-        'ccc',
-      ]);
-      t1.innerHTML = 'aaa<wbr>bbbb<wbr>ccc';
-      bw2.applyElement(t1);
-      validate(t1, [
-        'aaa',
-        { nodeName: 'wbr', classList: [1, 2] },
-        'bbbb',
-        { nodeName: 'wbr', classList: [2] },
-        'ccc',
-      ]);
       t1.innerHTML = 'aa<wbr>bbbb<wbr>ccc';
       bw2.applyElement(t1);
       validate(t1, [
@@ -76,20 +58,105 @@ describe('Japanese balanced word wrap', () => {
         'ccc',
       ]);
       t1.innerHTML = 'aaa<wbr>bbb<wbr>ccc<wbr>ddd<wbr>eee<wbr>fff';
-      bw2 = new BalancedWordWrapper();
       bw2.applyElement(t1);
       validate(t1, [
         'aaa',
-        { nodeName: 'wbr', classList: [3, 4, 5] },
+        { nodeName: 'wbr', classList: [] },
         'bbb',
-        { nodeName: 'wbr', classList: [2, 5] },
+        { nodeName: 'wbr', classList: [2] },
         'ccc',
-        { nodeName: 'wbr', classList: [1, 3, 4, 5] },
+        { nodeName: 'wbr', classList: [1] },
         'ddd',
-        { nodeName: 'wbr', classList: [2, 4, 5] },
+        { nodeName: 'wbr', classList: [2] },
         'eee',
-        { nodeName: 'wbr', classList: [3, 4, 5] },
+        { nodeName: 'wbr', classList: [] },
         'fff',
+      ]);
+      bw2 = new BalancedWordWrapper(3);
+      t1.innerHTML = '作ろうと<wbr>しているのは、<wbr>どのような<wbr>チラシですか。';
+      bw2.applyElement(t1);
+      validate(t1, [
+        '作ろうと',
+        { nodeName: 'wbr', classList: [3] },
+        'しているのは、',
+        { nodeName: 'wbr', classList: [1, 2, 3] },
+        'どのような',
+        { nodeName: 'wbr', classList: [2, 3] },
+        'チラシですか。',
+      ]);
+      t1.innerHTML = '作ろうと<wbr>しているのは、<wbr>どのような<wbr>バナーでしょうか。';
+      bw2.applyElement(t1);
+      validate(t1, [
+        '作ろうと',
+        { nodeName: 'wbr', classList: [3] },
+        'しているのは、',
+        { nodeName: 'wbr', classList: [1, 2, 3] },
+        'どのような',
+        { nodeName: 'wbr', classList: [2, 3] },
+        'バナーでしょうか。',
+      ]);
+      t1.innerHTML = '作ろうと<wbr>しているのは、<wbr>どのような<wbr>広告画像でしょうか。';
+      bw2.applyElement(t1);
+      validate(t1, [
+        '作ろうと',
+        { nodeName: 'wbr', classList: [3] },
+        'しているのは、',
+        { nodeName: 'wbr', classList: [1, 2, 3] },
+        'どのような',
+        { nodeName: 'wbr', classList: [2, 3] },
+        '広告画像でしょうか。',
+      ]);
+      t1.innerHTML = '逆再生された<wbr>ビデオクリップを<wbr>スピードアップしたり、<wbr>スローダウンしたりしましょう。';
+      bw2.applyElement(t1);
+      validate(t1, [
+        '逆再生された',
+        { nodeName: 'wbr', classList: [3] },
+        'ビデオクリップを',
+        { nodeName: 'wbr', classList: [2] },
+        'スピードアップしたり、',
+        { nodeName: 'wbr', classList: [1, 2, 3] },
+        'スローダウンしたりしましょう。',
+      ]);
+      t1.innerHTML = 'MOVファイルを<wbr>MP4<wbr>ビデオに<wbr>変換する<wbr>準備は<wbr>できましたか。';
+      bw2.applyElement(t1);
+      validate(t1, [
+        'MOVファイルを',
+        { nodeName: 'wbr', classList: [3] },
+        'MP4',
+        { nodeName: 'wbr', classList: [2] },
+        'ビデオに',
+        { nodeName: 'wbr', classList: [1, 3] },
+        '変換する',
+        { nodeName: 'wbr', classList: [2] },
+        '準備は',
+        { nodeName: 'wbr', classList: [3] },
+        'できましたか。',
+      ]);
+      t1.innerHTML = 'ビデオを<wbr>トリミングする<wbr>準備は<wbr>できましたか。';
+      bw2 = new BalancedWordWrapper(2);
+      bw2.applyElement(t1);
+      validate(t1, [
+        'ビデオを',
+        { nodeName: 'wbr', classList: [2] },
+        'トリミングする',
+        { nodeName: 'wbr', classList: [1] },
+        '準備は',
+        { nodeName: 'wbr', classList: [2] },
+        'できましたか。',
+      ]);
+      t1.innerHTML = 'Creative Cloud Expressで、<wbr>注目される<wbr>YouTube<wbr>チャンネルアートを<wbr>作成';
+      bw2 = new BalancedWordWrapper(1);
+      bw2.applyElement(t1);
+      validate(t1, [
+        'Creative Cloud Expressで、',
+        { nodeName: 'wbr', classList: [] },
+        '注目される',
+        { nodeName: 'wbr', classList: [1] },
+        'YouTube',
+        { nodeName: 'wbr', classList: [] },
+        'チャンネルアートを',
+        { nodeName: 'wbr', classList: [] },
+        '作成',
       ]);
     });
 
@@ -101,7 +168,32 @@ describe('Japanese balanced word wrap', () => {
       validate(t1, [
         'aaa', { nodeName: 'wbr' }, 'bbb',
       ]);
+      t1.innerHTML = '\uff3faaabbb';
+      bw2.applyElement(t1);
+      validate(t1, [
+        'aaabbb',
+      ]);
+      t1.innerHTML = '\uff3f\uff3faaabbb';
+      bw2.applyElement(t1);
+      validate(t1, [
+        'aaabbb',
+      ]);
+      t1.innerHTML = 'aaabbb\uff3f';
+      bw2.applyElement(t1);
+      validate(t1, [
+        'aaabbb', { nodeName: 'wbr' },
+      ]);
+      t1.innerHTML = 'aaabbb\uff3f\uff3f';
+      bw2.applyElement(t1);
+      validate(t1, [
+        'aaabbb', { nodeName: 'wbr' },
+      ]);
       t1.innerHTML = 'aaa\uff3f\uff3fbbb';
+      bw2.applyElement(t1);
+      validate(t1, [
+        'aaa', { nodeName: 'wbr' }, 'bbb',
+      ]);
+      t1.innerHTML = 'aaa\uff3f\uff3f<wbr>bbb';
       bw2.applyElement(t1);
       validate(t1, [
         'aaa', { nodeName: 'wbr' }, 'bbb',

--- a/test/unit/bw2.test.js
+++ b/test/unit/bw2.test.js
@@ -219,5 +219,51 @@ describe('Japanese balanced word wrap', () => {
         'aaa', { nodeName: 'wbr' }, 'bbb', { nodeName: 'wbr' }, 'ccc',
       ]);
     });
+
+    it('should handle nested tags properly', () => {
+      const bw2 = new BalancedWordWrapper(2);
+      const t1 = createTag('h1');
+      t1.innerHTML = '<strong class="foo">aa<wbr>bbbb<wbr>ccc</strong>';
+      bw2.applyElement(t1);
+      validate(t1.childNodes[0], [
+        'aa',
+        { nodeName: 'wbr', classList: [2] },
+        'bbbb',
+        { nodeName: 'wbr', classList: [1, 2] },
+        'ccc',
+      ]);
+      t1.innerHTML = '<strong class="foo">aa<wbr>bbbb<wbr>ccc</strong>ddd<wbr>eee';
+      // in this case, direct text children of t1 will be ignored by this logic and kept unchanged
+      bw2.applyElement(t1);
+      expect(t1.childNodes.length).to.equal(4);
+      validate(t1, [
+        { nodeName: 'strong' },
+        'ddd',
+        { nodeName: 'wbr', classList: [] },
+        'eee',
+      ]);
+      validate(t1.childNodes[0], [
+        'aa',
+        { nodeName: 'wbr', classList: [2] },
+        'bbbb',
+        { nodeName: 'wbr', classList: [1, 2] },
+        'ccc',
+      ]);
+      t1.innerHTML = '<strong class="foo">aaa\uff3fbbb</strong>';
+      bw2.applyElement(t1);
+      validate(t1.childNodes[0], [
+        'aaa', { nodeName: 'wbr' }, 'bbb',
+      ]);
+      t1.innerHTML = '<strong class="foo">\uff3faaabbb</strong>';
+      bw2.applyElement(t1);
+      validate(t1.childNodes[0], [
+        'aaabbb',
+      ]);
+      t1.innerHTML = '<strong class="foo">aaabbb\uff3f</strong>';
+      bw2.applyElement(t1);
+      validate(t1.childNodes[0], [
+        'aaabbb', { nodeName: 'wbr' },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is the logic to make Japanese headings wrap at positions so that the lines after word wrapping have more balanced lengths.

Before this change:
<img width="500" alt="Screen Shot 2022-03-15 at 18 39 42" src="https://user-images.githubusercontent.com/12515123/158349912-c7654c79-2d02-4ce3-bd76-31a8f3a94588.png">

After this change:
<img width="500" alt="Screen Shot 2022-03-15 at 18 39 20" src="https://user-images.githubusercontent.com/12515123/158350014-7afe605f-0c48-4a23-9a34-e8415b7dd825.png">

## Description

<!--- Describe your changes in detail -->
The logic uses [CanvasRenderingContext2D](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D) to measure actual text width, decides where to break lines based on the text width and existing `<wbr>` tag locations, and uses CSS style classes to switch on/off the `<wbr>` tags in [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/ResizeObserver) callback functions.

**Input:**

- HTML heading element object
- Maximum number of lines to be wrapped into (default value: 6)

**Output:**

The modified heading element object

**Flow of processing:**

<img width="200px" src="https://user-images.githubusercontent.com/12515123/168222367-04b3f3c9-210c-48d2-bb9a-4083853bfd48.png" />

### Terminologies

**Word wrap level**

Word wrap levels are numerical markers indicating the number of line breaks need to be inserted into the text. For instance, Level 1 means that only 1 line break is needed given the current text length and element width, i.e. the given text needs to be wrapped into 2 lines. Word wrap levels are specified as CSS class names in this solution. For instance, WBR tags which should be switched on at Level 1 are assigned with CSS class name "jpn-balanced-wbr-l1", and the tags which should be switched on at Level 2 are assigned with class name "jpn-balanced-wbr-l2".

**Word wrap separator**

Word wrap separators are the characters inserted into the text to indicate at which positions in the text can lines be broken. Separators can be inserted into texts either manually or automatically. WBR tags are one kind of word wrap separators.

### Inserting word wrap separators manually

There are cases where the auto-insertion of WBR tags into heading texts results in a suboptimal results. For instance, there may be on chunk of text which is too long to be displayed in one line but there were no WBR tags inserted by automatic logic inside the chunk. It's sensible in those cases to allow content author to insert word wrap indicators or separators manually. 

This solution currently allows to insert fullwidth low line, "＿" (U+FF3F), as a manual word wrap separator. All occurrences of the manual separator in the text will be replaced with WBR tags in the output.

### URL for testing:

- https://jpn-balanced-word-wrap--express-website--MasonPinZ.hlx3.page/jp/express/feature?lighthouse=on


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Default word wrapping logic in modern browsers fills the current line of text as full as possible before adding a line break at the line end. This logic applies to both paragraphs and headings. For heading texts, that logic may lead to a result where only very few characters are displayed on the second or latter lines. This consequently makes the line lengths very unbalanced among all lines of the same heading. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit tests have been added at `test/unit/bw2.test.js`.
- Manual tests have been done to ensure no regressions happen.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
