### PR TITLE
Ignore .idea files related to JetBrains and VS Code Studio IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .cache/
 .DS_Store
 .env
+.idea
 node_modules/
 pipeline.log
 logs

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 .env
 .idea
+.vscode/*
 node_modules/
 pipeline.log
 logs

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@
 .cache/
 .DS_Store
 .env
-.idea
-.vscode/*
+.idea/
+.vscode/
 node_modules/
 pipeline.log
 logs


### PR DESCRIPTION
Some developers work using IDEs from JetBrains or VS Code Studio and it would be good to be able to git ignore these files in order to avoid accidentally committing them to the project.