### PR TITLE
fix(fullsize-column): revert button being shown above text

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -554,18 +554,6 @@ main .columns.fullsize .hero-animation-overlay {
   order: -1;
 }
 
-main .columns.fullsize > div > div {
-  display: grid;
-}
-
-main .columns.fullsize > div > div .button-container {
-  grid-row: 2;
-}
-
-main .columns.fullsize .has-brand > div .button-container {
-  grid-row: 3;
-}
-
 main .columns.fullsize > div > div p {
   margin: 16px 0;
 }


### PR DESCRIPTION
Fix issue mentioned on slack: CTA Button appearing above text on fullsize column.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/drafts/Ankush%20hcl37284/express-your-fandom
- After: https://column-fullsize--express-website--webistry-development.hlx3.page/drafts/Ankush%20hcl37284/express-your-fandom

Testing other pages:

- [Before](https://main--express-website--adobe.hlx.page/express/create/logo) / [After](https://column-fullsize--express-website--webistry-development.hlx3.page/express/create/logo)
- [Before](https://main--express-website--adobe.hlx.page/express/feature/image/remove-background) / [After](https://column-fullsize--express-website--webistry-development.hlx3.page/express/feature/image/remove-background)

