### PR TITLE
feat: legal copy can start with * or †

### DIFF
--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -182,7 +182,8 @@ export default function decorate($block) {
 
       // legal copy
       $cell.querySelectorAll(':scope p').forEach(($p) => {
-        if ($p.textContent.trim().startsWith('* ')) {
+        const pText = $p.textContent.trim();
+        if (['*', '†'].includes(pText.charAt(0))) {
           $p.classList.add('legal-copy');
         }
       });


### PR DESCRIPTION
Paragraphs starting with `*` will be rendered as legal copy. The same should also work for paragraphs starting with `†`.

https://legal-copy-chars--express-website--adobe.hlx.page/express/feature
(scroll down to "take command of social content")