### PR TITLE
[WIP] fix: change the screen size of disabling budoux

### DIFF
--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -750,7 +750,7 @@ main .template-list-sixcols-container > div {
 }
 
 /* disable budoux on small screens  */
-@media (max-width: 600px) {
+@media (max-width: 900px) {
   h1.budoux, h2.budoux, h3.budoux, h4.budoux, h5.budoux {
     word-break: normal !important;
   }


### PR DESCRIPTION
# Overview

Fix layout issue problem on JP page caused by a side effect of BudouX

# Prerequisite knowledge 

- Correct and beautiful Japanese word wraps was achieved by Google BudouX
- The side effect of using BudouX `(word-break: keep-all , overflow-wrap: break-word)` is that text overflows the parent container when specifying `display: flex` and `flex-direction: column` for the parent element.
- To prevent this side effect, I’m disabling BudouX on mobile screen. The code is [here](https://github.com/adobe/express-website/blob/2ae5f9f32f1d6c166beffaf6325716ba551e234c/express/styles/styles.css#L753-L757). However, `(max-width: 600px)` is not enough size to prevent this side effect.

Test URLs:
- Before: https://main--express-website--adobe.hlx3.page/jp/express/feature
- After: https://fix-jp-layout-issue--express-website--tamanyan.hlx3.page/jp/express/feature
