### PR TITLE
fix: video detection too inclusive

### DIFF
--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -23,6 +23,7 @@ import {
 import {
   displayVideoModal,
   hideVideoModal,
+  isVideoLink,
 } from '../shared/video.js';
 
 function transformToVideoColumn($cell, $a) {
@@ -191,8 +192,7 @@ export default function decorate($block) {
       // this probably needs to be tighter and possibly earlier
       const $a = $cell.querySelector('a');
       if ($a) {
-        if (($a.href.includes('vimeo') || $a.href.includes('youtu') || $a.href.includes('/media_'))
-          && $row.parentElement.classList.contains('highlight')) {
+        if (isVideoLink($a.href) && $row.parentElement.classList.contains('highlight')) {
           transformToVideoColumn($cell, $a);
 
           $a.addEventListener('click', (e) => {


### PR DESCRIPTION
The check for video links is too inclusive, it only checks for `/media_` but not the extension. We already have a method for that: `isVideoLink()`.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/drafts/Anuj/55775
- After: https://columns-video-detection--express-website--adobe.hlx.page/drafts/Anuj/55775?lighthouse=on
