### PR TITLE
fix(scripts/scripts.js): remove underlines

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -928,6 +928,11 @@ export function decorateButtons(block = document) {
   const noButtonBlocks = ['template-list', 'icon-list'];
   block.querySelectorAll(':scope a').forEach(($a) => {
     const originalHref = $a.href;
+    if ($a.children.length > 0) {
+      // We can use this to eliminate styling so only text
+      // propagates to buttons.
+      $a.innerHTML = $a.innerHTML.replaceAll('<u>', '').replaceAll('</u>', '');
+    }
     $a.href = addSearchQueryToHref($a.href);
     $a.title = $a.title || $a.textContent;
     const $block = $a.closest('div.section-wrapper > div > div');


### PR DESCRIPTION
ensure buttons don't have excessive styling like underlines and more

You'll observe that one of the buttons' had underlined text within the button, because Word propagates the underlining through our Pipeline! 

](https://files.slack.com/files-pri/T23RE8G4F-F03F516SVC0/screen_shot_2022-05-06_at_11.39.00_am.png)

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/drafts/mrosier/instagram-logo-for-business-cards-copy
- After: https://handle-button-underline--express-website--adobe.hlx.page/drafts/mrosier/instagram-logo-for-business-cards-copy?lighthouse=on
