### PR TITLE
fix(how-to-step-carousel): support cta link with the tip text

### DIFF
--- a/express/blocks/how-to-steps-carousel/how-to-steps-carousel.css
+++ b/express/blocks/how-to-steps-carousel/how-to-steps-carousel.css
@@ -29,6 +29,10 @@ main .how-to-steps-carousel-container > div p.button-container a {
   margin: 0;
 }
 
+main .how-to-steps-carousel-container > div p.button-container {
+    margin: 16px 0;
+}
+
 main .how-to-steps-carousel-container > div > h2 {
   font-size: var(--heading-font-size-xl);
   text-align: left;
@@ -133,7 +137,8 @@ main .how-to-steps-carousel .tip-number span {
   transform: translate(-50%, -50%);
 }
 
-main .how-to-steps-carousel .tip-text p {
+main .how-to-steps-carousel .tip-text p,
+main .how-to-steps-carousel .tip-text div {
   font-size: var(--body-font-size-xl);
   margin-top: 16px;
   margin-bottom: 0;
@@ -200,6 +205,11 @@ main .how-to-steps-carousel-container .icon {
 
   main .how-to-steps-carousel-container.no-cover > picture > img {
     object-fit: contain;
+  }
+
+  main .how-to-steps-carousel-container > div p.button-container {
+    margin: 0;
+    margin-top: 40px;
   }
 }
 

--- a/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
+++ b/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
@@ -119,11 +119,9 @@ export default function decorate(block) {
 
     const h3 = createTag('h3');
     h3.innerHTML = cells[0].textContent;
-    const p = createTag('p');
-    p.innerHTML = cells[1].textContent;
     const text = createTag('div', { class: 'tip-text' });
     text.append(h3);
-    text.append(p);
+    text.append(cells[1]);
 
     row.innerHTML = '';
     row.append(text);

--- a/test/unit/blocks/expected/how-to-steps-carousel.section.html
+++ b/test/unit/blocks/expected/how-to-steps-carousel.section.html
@@ -15,19 +15,23 @@
         <div class="tip tip-3" data-tip-index="3">
           <div class="tip-text">
             <h3>Title for Step 3</h3>
-            <p>Text content for Step 3.</p>
+            <div>
+              <p>Text content for Step 3.</p>
+              <p><a href="#">Some link.</a></p>
+            </div>
           </div>
         </div>
         <div class="tip tip-2" data-tip-index="2">
           <div class="tip-text">
             <h3>Title for Step 2</h3>
-            <p>Text content for Step 2.</p>
+            <div>Text content <a href="#">with link</a> for Step 2<p></p>
+            </div>
           </div>
         </div>
         <div class="tip tip-1 active" data-tip-index="1">
           <div class="tip-text">
             <h3>Title for Step 1</h3>
-            <p>Text content for Step 1.</p>
+            <div>Text content for Step 1.</div>
           </div>
         </div>
       </div>

--- a/test/unit/blocks/input/how-to-steps-carousel.doc.html
+++ b/test/unit/blocks/input/how-to-steps-carousel.doc.html
@@ -19,11 +19,11 @@
         </div>
         <div>
           <div>Title for Step 2</div>
-          <div>Text content for Step 2.</div>
+          <div>Text content <a href="#">with link</a> for Step 2</p></div>
         </div>
         <div>
           <div>Title for Step 3</div>
-          <div>Text content for Step 3.</div>
+          <div><p>Text content for Step 3.</p><p><a href="#">Some link.</a></p></div>
         </div>
       </div>
       <p><a href="https://www.adobe.com/express">Button</a></p>


### PR DESCRIPTION
When adding a link in a tip (inline link and cta button), the link is removed.

On test page: check the tips, they all have at least one link! (missing in the before case).

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/drafts/alex/howto?lighthouse=on
- After: https://how-to-step-with-cta--express-website--adobe.hlx.page/drafts/alex/howto?lighthouse=on
