### PR TITLE
chore(banner): remove bottom spacing from light container

### DIFF
--- a/express/blocks/banner/banner.css
+++ b/express/blocks/banner/banner.css
@@ -4,7 +4,7 @@ main .section-wrapper.banner-container {
 }
 
 main .section-wrapper.banner-light-container {
-  padding: 80px 15px;
+  padding: 80px 15px 0;
 }
 
 main .section-wrapper:first-of-type {


### PR DESCRIPTION
Reduce the spacing between a light banner and the next section.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/drafts/Anuj/enterprise-nation
- After: https://banner-light-spacing--express-website--adobe.hlx.page/drafts/Anuj/enterprise-nation?lighthouse=on
