### PR TITLE
fix: stop applying budoux effect to p tags

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1770,7 +1770,7 @@ async function wordBreakJapanese() {
   }
   const { loadDefaultJapaneseParser } = await import('./budoux-index-ja.min.js');
   const parser = loadDefaultJapaneseParser();
-  document.querySelectorAll('h1, h2, h3, h4, h5, p:not(.button-container)').forEach((el) => {
+  document.querySelectorAll('h1, h2, h3, h4, h5').forEach((el) => {
     parser.applyElement(el);
   });
 


### PR DESCRIPTION
Fix https://jira.corp.adobe.com/browse/DOTCOM-65006

Test URLs:

Before: https://main--express-website--adobe.hlx3.page/jp/express/learn/blog/creative-cloud-express-whats-new-font-recommendations
After: https://budoux-disable-ptag--express-website--tamanyan.hlx3.page/jp/express/learn/blog/creative-cloud-express-whats-new-font-recommendations