### PR TITLE
fix(make-a-project): some icons not clickable

### DIFF
--- a/express/blocks/make-a-project/make-a-project.js
+++ b/express/blocks/make-a-project/make-a-project.js
@@ -16,9 +16,11 @@ export default function decorate($block) {
     // decorate project links
     $marquee.querySelectorAll(':scope ul li a').forEach(($link) => {
       const $icon = $link.previousSibling;
-      if ($icon && $icon.firstElementChild) {
-        // remove title from SVG
-        $icon.firstElementChild.remove();
+      if ($icon) {
+        if ($icon.firstElementChild) {
+          // remove title from SVG
+          $icon.firstElementChild.remove();
+        }
         $link.prepend($icon);
       }
     });


### PR DESCRIPTION
Some icons are not clickable in the _make a project_ block. This happens when icons are not part of the icon sprite.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/drafts/rofe/home
- After: https://make-project-icon-fix--express-website--adobe.hlx.page/drafts/rofe/home?lighthouse=on
