### PR TITLE
fix(/blocks/template-list/template-list.css):

### DIFF
--- a/express/blocks/template-list/template-list.css
+++ b/express/blocks/template-list/template-list.css
@@ -175,7 +175,7 @@ main .template-list.sixcols .template {
 }
 
 main .template-list .template:not(.placeholder) > div:first-of-type {
-  overflow: hidden;
+  /*overflow: hidden*/;
   border-radius: 7px;
   line-height: 0;
 }


### PR DESCRIPTION
images are hidden in block in Safari because the images overflow a container of 0 height

Fix https://github.com/adobe/express-website-issues/issues/346

Test URLs:
- Before in SAFARI: https://www.adobe.com/express/learn/blog/pride-month-zoom-backgrounds-and-lgbtq-posters
- After in SAFARI: https://fix-template-list-bug--express-website--adobe.hlx.page/express/learn/blog/pride-month-zoom-backgrounds-and-lgbtq-posters
