### PR TITLE
feat(analytics): tracking video close

### DIFF
--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -526,6 +526,22 @@ loadScript(martechURL, () => {
     document.addEventListener('videoloaded', (e) => {
       trackVideoAnalytics(e.detail.video, e.detail.parameters);
     });
+
+    document.addEventListener('videoclosed', (e) => {
+      console.log(e.detail);
+      const adobeEventName = `adobe.com:express:cta:learn:columns:${e.detail.parameters.videoId}:videoClosed`;
+      const sparkEventName = 'landing:videoClosed';
+
+      digitalData._set('primaryEvent.eventInfo.eventName', adobeEventName);
+      digitalData._set('spark.eventData.eventName', sparkEventName);
+
+      _satellite.track('event', {
+        digitalData: digitalData._snapshot(),
+      });
+
+      digitalData._delete('primaryEvent.eventInfo.eventName');
+      digitalData._delete('spark.eventData.eventName');
+    });
   }
 
   decorateAnalyticsEvents();


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

No issue provided

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/
- After: https://meta-analytics--express-website--webistry-development.hlx3.page/express/learn/express-your-brand

This branch adds tracking to the following actions:
- Closing a video modal by clicking the x icon
- Closing a video modal by clicking the overlay behind the video
- Closing a video modal by pressing escape

It does not cover the following action:
- Closing a video by removing the hashtag from the url
