### PR TITLE
Jpn font sizing

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -145,6 +145,12 @@ main .columns h2.columns-heading-very-long {
   }
 }
 
+@media (max-width: 600px) {
+  :lang(ja) main .columns h2 {
+    font-size: var(--heading-font-size-l);
+  }
+}
+
 main .columns h3 {
   font-size: var(--heading-font-size-l);
   line-height: 1.11;

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -766,6 +766,10 @@ main .columns.highlight .column.column-picture {
 }
 
 @media (min-width: 1200px) {
+  :lang(ja) main .columns h1{
+    font-size: var(--heading-font-size-xxl);
+  }
+
   :lang(ja) main .columns h1.columns-heading-long {
     font-size: var(--heading-font-size-xl);
   }
@@ -805,6 +809,24 @@ main .columns.highlight .column.column-picture {
   }
 
   :lang(ja) main .columns h2.columns-heading-x-long {
+    font-size: var(--heading-font-size-m);
+  }
+}
+
+@media (min-width: 900px) and (max-width: 1200px) {
+  :lang(ja) main .columns h1{
+    font-size: var(--heading-font-size-xl);
+  }
+
+  :lang(ja) main .columns h1.columns-heading-long {
+    font-size: var(--heading-font-size-xl);
+  }
+
+  :lang(ja) main .columns h1.columns-heading-very-long {
+    font-size: var(--heading-font-size-l);
+  }
+
+  :lang(ja) main .columns h1.columns-heading-x-long {
     font-size: var(--heading-font-size-m);
   }
 }

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -113,17 +113,35 @@ main .columns h2.columns-heading-very-long {
   font-size: var(--heading-font-size-l);
 }
 
-main .columns h2.columns-heading-x-long {
-  font-size: var(--heading-font-size-m);
-}
-
 @media (min-width: 1200px) {
   main .columns h2.columns-heading-very-long {
     font-size: var(--heading-font-size-xl);
   }
+}
 
-  main .columns h2.columns-heading-x-long {
+:lang(ja) main .columns h2.columns-heading-long {
+  font-size: var(--heading-font-size-l);
+}
+
+:lang(ja) main .columns h2.columns-heading-very-long {
+  font-size: var(--heading-font-size-m);
+}
+
+:lang(ja) main .columns h2.columns-heading-x-long {
+  font-size: var(--heading-font-size-m);
+}
+
+@media (min-width: 1200px) {
+  :lang(ja) main .columns h2.columns-heading-long {
+    font-size: var(--heading-font-size-xl);
+  }
+
+  :lang(ja) main .columns h2.columns-heading-very-long {
     font-size: var(--heading-font-size-l);
+  }
+
+  :lang(ja) main .columns h2.columns-heading-x-long {
+    font-size: var(--heading-font-size-m);
   }
 }
 

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -766,8 +766,28 @@ main .columns.highlight .column.column-picture {
 }
 
 @media (min-width: 1200px) {
+  :lang(ja) main .columns h1.columns-heading-long {
+    font-size: var(--heading-font-size-xl);
+  }
+
+  :lang(ja) main .columns h1.columns-heading-very-long {
+    font-size: var(--heading-font-size-xl);
+  }
+
+  :lang(ja) main .columns h1.columns-heading-x-long {
+    font-size: var(--heading-font-size-l);
+  }
+
   :lang(ja) main .columns h2.columns-heading-long {
     font-size: var(--heading-font-size-xl);
+  }
+
+  :lang(ja) main .columns h2.columns-heading-very-long {
+    font-size: var(--heading-font-size-l);
+  }
+
+  :lang(ja) main .columns h2.columns-heading-x-long {
+    font-size: var(--heading-font-size-m);
   }
 }
 
@@ -776,7 +796,15 @@ main .columns.highlight .column.column-picture {
     font-size: var(--heading-font-size-l);
   }
 
+  :lang(ja) main .columns h2.columns-heading-long {
+    font-size: var(--heading-font-size-l);
+  }
+
   :lang(ja) main .columns h2.columns-heading-very-long {
+    font-size: var(--heading-font-size-m);
+  }
+
+  :lang(ja) main .columns h2.columns-heading-x-long {
     font-size: var(--heading-font-size-m);
   }
 }

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -124,7 +124,7 @@ main .columns h2.columns-heading-very-long {
 }
 
 :lang(ja) main .columns h2.columns-heading-very-long {
-  font-size: var(--heading-font-size-m);
+  font-size: var(--heading-font-size-l);
 }
 
 :lang(ja) main .columns h2.columns-heading-x-long {
@@ -135,19 +135,15 @@ main .columns h2.columns-heading-very-long {
   :lang(ja) main .columns h2.columns-heading-long {
     font-size: var(--heading-font-size-xl);
   }
-
-  :lang(ja) main .columns h2.columns-heading-very-long {
-    font-size: var(--heading-font-size-l);
-  }
-
-  :lang(ja) main .columns h2.columns-heading-x-long {
-    font-size: var(--heading-font-size-m);
-  }
 }
 
 @media (max-width: 600px) {
   :lang(ja) main .columns h2 {
     font-size: var(--heading-font-size-l);
+  }
+
+  :lang(ja) main .columns h2.columns-heading-very-long {
+    font-size: var(--heading-font-size-m);
   }
 }
 

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -113,9 +113,17 @@ main .columns h2.columns-heading-very-long {
   font-size: var(--heading-font-size-l);
 }
 
+main .columns h2.columns-heading-x-long {
+  font-size: var(--heading-font-size-m);
+}
+
 @media (min-width: 1200px) {
   main .columns h2.columns-heading-very-long {
     font-size: var(--heading-font-size-xl);
+  }
+
+  main .columns h2.columns-heading-x-long {
+    font-size: var(--heading-font-size-l);
   }
 }
 

--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -119,34 +119,6 @@ main .columns h2.columns-heading-very-long {
   }
 }
 
-:lang(ja) main .columns h2.columns-heading-long {
-  font-size: var(--heading-font-size-l);
-}
-
-:lang(ja) main .columns h2.columns-heading-very-long {
-  font-size: var(--heading-font-size-l);
-}
-
-:lang(ja) main .columns h2.columns-heading-x-long {
-  font-size: var(--heading-font-size-m);
-}
-
-@media (min-width: 1200px) {
-  :lang(ja) main .columns h2.columns-heading-long {
-    font-size: var(--heading-font-size-xl);
-  }
-}
-
-@media (max-width: 600px) {
-  :lang(ja) main .columns h2 {
-    font-size: var(--heading-font-size-l);
-  }
-
-  :lang(ja) main .columns h2.columns-heading-very-long {
-    font-size: var(--heading-font-size-m);
-  }
-}
-
 main .columns h3 {
   font-size: var(--heading-font-size-l);
   line-height: 1.11;
@@ -777,5 +749,34 @@ main .columns.highlight .column.column-picture {
 
   main .columns .column:nth-child(2):not(.column-picture):not(.hero-animation-overlay) {
     padding-left: 16px;
+  }
+}
+
+/* Japanese font sizing styles */
+:lang(ja) main .columns h2.columns-heading-long {
+  font-size: var(--heading-font-size-l);
+}
+
+:lang(ja) main .columns h2.columns-heading-very-long {
+  font-size: var(--heading-font-size-l);
+}
+
+:lang(ja) main .columns h2.columns-heading-x-long {
+  font-size: var(--heading-font-size-m);
+}
+
+@media (min-width: 1200px) {
+  :lang(ja) main .columns h2.columns-heading-long {
+    font-size: var(--heading-font-size-xl);
+  }
+}
+
+@media (max-width: 600px) {
+  :lang(ja) main .columns h2 {
+    font-size: var(--heading-font-size-l);
+  }
+
+  :lang(ja) main .columns h2.columns-heading-very-long {
+    font-size: var(--heading-font-size-m);
   }
 }

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -19,6 +19,7 @@ import {
   getLocale,
   getIconElement,
   addFreePlanWidget,
+  addHeaderSizing,
 } from '../../scripts/scripts.js';
 
 import {
@@ -123,40 +124,6 @@ function decorateIconList($columnCell, rowNum, blockClasses) {
     });
     if ($iconList.children.length > 0) $columnCell.appendChild($iconList);
   }
-}
-
-function getJapaneseTextCharacterCount(text) {
-  const headingEngCharsRegEx = /[a-zA-Z0-9 ]+/gm;
-  const matches = text.matchAll(headingEngCharsRegEx);
-  const eCnt = [...matches].map((m) => m[0]).reduce((cnt, m) => cnt + m.length, 0);
-  const jtext = text.replaceAll(headingEngCharsRegEx, '');
-  const jCnt = jtext.length;
-  return eCnt * 0.57 + jCnt;
-}
-
-function addHeaderSizing($block) {
-  const headings = $block.querySelectorAll('h1, h2');
-  // Each threshold of JP should be smaller than other languages
-  // because JP characters are larger and JP sentences are longer
-  const sizes = getLocale(window.location) === 'jp'
-    ? [
-      { name: 'long', threshold: 8 },
-      { name: 'very-long', threshold: 11 },
-      { name: 'x-long', threshold: 15 },
-    ]
-    : [
-      { name: 'long', threshold: 30 },
-      { name: 'very-long', threshold: 40 },
-      { name: 'x-long', threshold: 50 },
-    ];
-  headings.forEach((h) => {
-    const length = getLocale(window.location) === 'jp'
-      ? getJapaneseTextCharacterCount(h.textContent)
-      : h.textContent.length;
-    sizes.forEach((size) => {
-      if (length >= size.threshold) h.classList.add(`columns-heading-${size.name}`);
-    });
-  });
 }
 
 export default function decorate($block) {
@@ -270,7 +237,7 @@ export default function decorate($block) {
     });
   });
   addAnimationToggle($block);
-  addHeaderSizing($block);
+  addHeaderSizing($block, 'columns-heading');
 
   // decorate offer
   if ($block.classList.contains('offer')) {

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -125,15 +125,24 @@ function decorateIconList($columnCell, rowNum, blockClasses) {
   }
 }
 
+function getJapaneseTextCharacterCount(text) {
+  const headingEngCharsRegEx = /[a-zA-Z0-9 ]+/gm;
+  const matches = text.matchAll(headingEngCharsRegEx);
+  const eCnt = [...matches].map((m) => m[0]).reduce((cnt, m) => cnt + m.length, 0);
+  const jtext = text.replaceAll(headingEngCharsRegEx, '');
+  const jCnt = jtext.length;
+  return eCnt * 0.57 + jCnt;
+}
+
 function addHeaderSizing($block) {
   const headings = $block.querySelectorAll('h1, h2');
   // Each threshold of JP should be smaller than other languages
   // because JP characters are larger and JP sentences are longer
   const sizes = getLocale(window.location) === 'jp'
     ? [
-      { name: 'long', threshold: 12 },
-      { name: 'very-long', threshold: 18 },
-      { name: 'x-long', threshold: 24 },
+      { name: 'long', threshold: 10 },
+      { name: 'very-long', threshold: 12 },
+      { name: 'x-long', threshold: 16 },
     ]
     : [
       { name: 'long', threshold: 30 },
@@ -141,7 +150,9 @@ function addHeaderSizing($block) {
       { name: 'x-long', threshold: 50 },
     ];
   headings.forEach((h) => {
-    const { length } = h.textContent;
+    const length = getLocale(window.location) === 'jp'
+      ? getJapaneseTextCharacterCount(h.textContent)
+      : h.textContent.length;
     sizes.forEach((size) => {
       if (length >= size.threshold) h.classList.add(`columns-heading-${size.name}`);
     });

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -16,7 +16,6 @@ import {
   transformLinkToAnimation,
   addAnimationToggle,
   toClassName,
-  getLocale,
   getIconElement,
   addFreePlanWidget,
   addHeaderSizing,

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -140,9 +140,9 @@ function addHeaderSizing($block) {
   // because JP characters are larger and JP sentences are longer
   const sizes = getLocale(window.location) === 'jp'
     ? [
-      { name: 'long', threshold: 10 },
-      { name: 'very-long', threshold: 12 },
-      { name: 'x-long', threshold: 16 },
+      { name: 'long', threshold: 8 },
+      { name: 'very-long', threshold: 11 },
+      { name: 'x-long', threshold: 15 },
     ]
     : [
       { name: 'long', threshold: 30 },

--- a/express/blocks/hero-animation/hero-animation.css
+++ b/express/blocks/hero-animation/hero-animation.css
@@ -106,6 +106,22 @@ main .hero-animation h1 {
   margin: 0 0 8px 0;
 }
 
+:lang(ja) main .hero-animation h1 {
+    font-size: var(--heading-font-size-l);
+}
+
+:lang(ja) main .hero-animation h1.heading-long {
+  font-size: var(--heading-font-size-l);
+}
+
+:lang(ja) main .hero-animation h1.heading-very-long {
+  font-size: var(--heading-font-size-m);
+}
+
+:lang(ja) main .hero-animation h1.heading-x-long {
+  font-size: var(--heading-font-size-m);
+}
+
 main .hero-animation .icon-adobe-creative-cloud-express {
   margin-top: 13px;
   height: 33px;

--- a/express/blocks/hero-animation/hero-animation.css
+++ b/express/blocks/hero-animation/hero-animation.css
@@ -106,22 +106,6 @@ main .hero-animation h1 {
   margin: 0 0 8px 0;
 }
 
-:lang(ja) main .hero-animation h1 {
-    font-size: var(--heading-font-size-l);
-}
-
-:lang(ja) main .hero-animation h1.heading-long {
-  font-size: var(--heading-font-size-l);
-}
-
-:lang(ja) main .hero-animation h1.heading-very-long {
-  font-size: var(--heading-font-size-m);
-}
-
-:lang(ja) main .hero-animation h1.heading-x-long {
-  font-size: var(--heading-font-size-m);
-}
-
 main .hero-animation .icon-adobe-creative-cloud-express {
   margin-top: 13px;
   height: 33px;
@@ -199,6 +183,23 @@ main .hero-animation .hero-animation-overlay p.button-container a.button:any-lin
   main .hero-animation-dark-container > div {
     max-width: 65%;
   }   
+}
+
+/* Japanese font sizing styles */
+:lang(ja) main .hero-animation h1 {
+    font-size: var(--heading-font-size-l);
+}
+
+:lang(ja) main .hero-animation h1.heading-long {
+    font-size: var(--heading-font-size-l);
+}
+
+:lang(ja) main .hero-animation h1.heading-very-long {
+    font-size: var(--heading-font-size-m);
+}
+
+:lang(ja) main .hero-animation h1.heading-x-long {
+    font-size: var(--heading-font-size-m);
 }
 
 

--- a/express/blocks/hero-animation/hero-animation.js
+++ b/express/blocks/hero-animation/hero-animation.js
@@ -15,6 +15,7 @@ import {
   addFreePlanWidget,
   createTag,
   toClassName,
+  addHeaderSizing,
 // eslint-disable-next-line import/no-unresolved
 } from '../../scripts/scripts.js';
 
@@ -292,5 +293,6 @@ export default async function decorate($block) {
   if ($block.classList.contains('wide')) {
     addAnimationToggle($block);
   }
+  addHeaderSizing($block);
   $block.classList.add('appear');
 }

--- a/express/blocks/hero-animation/hero-animation.js
+++ b/express/blocks/hero-animation/hero-animation.js
@@ -15,6 +15,7 @@ import {
   addFreePlanWidget,
   createTag,
   toClassName,
+  getLocale,
   addHeaderSizing,
 // eslint-disable-next-line import/no-unresolved
 } from '../../scripts/scripts.js';
@@ -293,6 +294,8 @@ export default async function decorate($block) {
   if ($block.classList.contains('wide')) {
     addAnimationToggle($block);
   }
-  addHeaderSizing($block);
+  if (getLocale(window.location) === 'jp') {
+    addHeaderSizing($block);
+  }
   $block.classList.add('appear');
 }

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1842,6 +1842,15 @@ async function wordBreakJapanese() {
   });
 }
 
+/**
+ * Calculate a relatively more accurate "character count" for mixed Japanese
+ * + English texts, for the purpose of heading auto font sizing.
+ *
+ * The rationale is that English characters are usually narrower than Japanese
+ * ones. Hence each English character (and space character) is multiplied by an
+ * coefficient before being added to the total character count. The current
+ * coefficient value, 0.57, is an empirical value from some tests.
+ */
 function getJapaneseTextCharacterCount(text) {
   const headingEngCharsRegEx = /[a-zA-Z0-9 ]+/gm;
   const matches = text.matchAll(headingEngCharsRegEx);
@@ -1851,6 +1860,15 @@ function getJapaneseTextCharacterCount(text) {
   return eCnt * 0.57 + jCnt;
 }
 
+/**
+ * Add dynamic font sizing CSS class names to headings
+ *
+ * The CSS class names are determined by character counts.
+ * @param {Element} $block The container element
+ * @param {string} classPrefix Prefix in CSS class names before "-long", "-very-long", "-x-long".
+ * Default is "heading".
+ * @param {string} selector CSS selector to select the target heading tags. Default is "h1, h2".
+ */
 export function addHeaderSizing($block, classPrefix = 'heading', selector = 'h1, h2') {
   const headings = $block.querySelectorAll(selector);
   // Each threshold of JP should be smaller than other languages
@@ -1876,6 +1894,10 @@ export function addHeaderSizing($block, classPrefix = 'heading', selector = 'h1,
   });
 }
 
+/**
+ * Call `addHeaderSizing` on default content blocks in all section blocks
+ * in all Japanese pages except blog pages.
+ */
 function addJapaneseSectionHeaderSizing() {
   if (getLocale(window.location) === 'jp') {
     document.querySelectorAll('body:not(.blog) .section .default-content-wrapper').forEach((el) => {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -403,49 +403,6 @@ export function readBlockConfig($block) {
   return config;
 }
 
-export function getLocale(url) {
-  const locale = url.pathname.split('/')[1];
-  if (/^[a-z]{2}$/.test(locale)) {
-    return locale;
-  }
-  return 'us';
-}
-
-function getJapaneseTextCharacterCount(text) {
-  const headingEngCharsRegEx = /[a-zA-Z0-9 ]+/gm;
-  const matches = text.matchAll(headingEngCharsRegEx);
-  const eCnt = [...matches].map((m) => m[0]).reduce((cnt, m) => cnt + m.length, 0);
-  const jtext = text.replaceAll(headingEngCharsRegEx, '');
-  const jCnt = jtext.length;
-  return eCnt * 0.57 + jCnt;
-}
-
-function addHeaderSizing($block) {
-  const headings = $block.querySelectorAll('h1, h2');
-  // Each threshold of JP should be smaller than other languages
-  // because JP characters are larger and JP sentences are longer
-  const sizes = getLocale(window.location) === 'jp'
-    ? [
-      { name: 'long', threshold: 8 },
-      { name: 'very-long', threshold: 11 },
-      { name: 'x-long', threshold: 15 },
-    ]
-    : [
-      { name: 'long', threshold: 30 },
-      { name: 'very-long', threshold: 40 },
-      { name: 'x-long', threshold: 50 },
-    ];
-  headings.forEach((h) => {
-    const length = getLocale(window.location) === 'jp'
-      ? getJapaneseTextCharacterCount(h.textContent)
-      : h.textContent.length;
-    // const { length } = h.textContent;
-    sizes.forEach((size) => {
-      if (length >= size.threshold) h.classList.add(`heading-${size.name}`);
-    });
-  });
-}
-
 /**
  * Decorates all sections in a container element.
  * @param {Element} $main The container element
@@ -483,8 +440,6 @@ export function decorateSections($main) {
       });
       sectionMeta.remove();
     }
-
-    addHeaderSizing(section);
   });
 }
 
@@ -507,6 +462,14 @@ export function updateSectionsStatus(main) {
       }
     }
   }
+}
+
+export function getLocale(url) {
+  const locale = url.pathname.split('/')[1];
+  if (/^[a-z]{2}$/.test(locale)) {
+    return locale;
+  }
+  return 'us';
 }
 
 function getCookie(cname) {
@@ -2081,6 +2044,41 @@ export function trackBranchParameters($links) {
       }
     });
   }
+}
+
+function getJapaneseTextCharacterCount(text) {
+  const headingEngCharsRegEx = /[a-zA-Z0-9 ]+/gm;
+  const matches = text.matchAll(headingEngCharsRegEx);
+  const eCnt = [...matches].map((m) => m[0]).reduce((cnt, m) => cnt + m.length, 0);
+  const jtext = text.replaceAll(headingEngCharsRegEx, '');
+  const jCnt = jtext.length;
+  return eCnt * 0.57 + jCnt;
+}
+
+export function addHeaderSizing($block, classPrefix = 'heading') {
+  const headings = $block.querySelectorAll('h1, h2');
+  // Each threshold of JP should be smaller than other languages
+  // because JP characters are larger and JP sentences are longer
+  const sizes = getLocale(window.location) === 'jp'
+    ? [
+      { name: 'long', threshold: 8 },
+      { name: 'very-long', threshold: 11 },
+      { name: 'x-long', threshold: 15 },
+    ]
+    : [
+      { name: 'long', threshold: 30 },
+      { name: 'very-long', threshold: 40 },
+      { name: 'x-long', threshold: 50 },
+    ];
+  headings.forEach((h) => {
+    const length = getLocale(window.location) === 'jp'
+      ? getJapaneseTextCharacterCount(h.textContent)
+      : h.textContent.length;
+    // const { length } = h.textContent;
+    sizes.forEach((size) => {
+      if (length >= size.threshold) h.classList.add(`${classPrefix}-${size.name}`);
+    });
+  });
 }
 
 if (window.name.includes('performance')) registerPerformanceLogger();

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -403,6 +403,49 @@ export function readBlockConfig($block) {
   return config;
 }
 
+export function getLocale(url) {
+  const locale = url.pathname.split('/')[1];
+  if (/^[a-z]{2}$/.test(locale)) {
+    return locale;
+  }
+  return 'us';
+}
+
+function getJapaneseTextCharacterCount(text) {
+  const headingEngCharsRegEx = /[a-zA-Z0-9 ]+/gm;
+  const matches = text.matchAll(headingEngCharsRegEx);
+  const eCnt = [...matches].map((m) => m[0]).reduce((cnt, m) => cnt + m.length, 0);
+  const jtext = text.replaceAll(headingEngCharsRegEx, '');
+  const jCnt = jtext.length;
+  return eCnt * 0.57 + jCnt;
+}
+
+function addHeaderSizing($block) {
+  const headings = $block.querySelectorAll('h1, h2');
+  // Each threshold of JP should be smaller than other languages
+  // because JP characters are larger and JP sentences are longer
+  const sizes = getLocale(window.location) === 'jp'
+    ? [
+      { name: 'long', threshold: 10 },
+      { name: 'very-long', threshold: 12 },
+      { name: 'x-long', threshold: 16 },
+    ]
+    : [
+      { name: 'long', threshold: 30 },
+      { name: 'very-long', threshold: 40 },
+      { name: 'x-long', threshold: 50 },
+    ];
+  headings.forEach((h) => {
+    const length = getLocale(window.location) === 'jp'
+      ? getJapaneseTextCharacterCount(h.textContent)
+      : h.textContent.length;
+    // const { length } = h.textContent;
+    sizes.forEach((size) => {
+      if (length >= size.threshold) h.classList.add(`heading-${size.name}`);
+    });
+  });
+}
+
 /**
  * Decorates all sections in a container element.
  * @param {Element} $main The container element
@@ -440,6 +483,8 @@ export function decorateSections($main) {
       });
       sectionMeta.remove();
     }
+
+    addHeaderSizing(section);
   });
 }
 
@@ -462,14 +507,6 @@ export function updateSectionsStatus(main) {
       }
     }
   }
-}
-
-export function getLocale(url) {
-  const locale = url.pathname.split('/')[1];
-  if (/^[a-z]{2}$/.test(locale)) {
-    return locale;
-  }
-  return 'us';
 }
 
 function getCookie(cname) {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -404,46 +404,6 @@ export function readBlockConfig($block) {
 }
 
 /**
- * Decorates all sections in a container element.
- * @param {Element} $main The container element
- */
-export function decorateSections($main) {
-  $main.querySelectorAll(':scope > div').forEach((section) => {
-    const wrappers = [];
-    let defaultContent = false;
-    [...section.children].forEach((e) => {
-      if (e.tagName === 'DIV' || !defaultContent) {
-        const wrapper = document.createElement('div');
-        wrappers.push(wrapper);
-        defaultContent = e.tagName !== 'DIV';
-        if (defaultContent) wrapper.classList.add('default-content-wrapper');
-      }
-      wrappers[wrappers.length - 1].append(e);
-    });
-    wrappers.forEach((wrapper) => section.append(wrapper));
-    section.classList.add('section', 'section-wrapper'); // keep .section-wrapper for compatibility
-    section.setAttribute('data-section-status', 'initialized');
-
-    /* process section metadata */
-    const sectionMeta = section.querySelector('div.section-metadata');
-    if (sectionMeta) {
-      const meta = readBlockConfig(sectionMeta);
-      const keys = Object.keys(meta);
-      keys.forEach((key) => {
-        if (key === 'style') {
-          section.classList.add(toClassName(meta.style));
-        } else if (key === 'anchor') {
-          section.id = toClassName(meta.anchor);
-        } else {
-          section.dataset[key] = meta[key];
-        }
-      });
-      sectionMeta.remove();
-    }
-  });
-}
-
-/**
  * Updates all section status in a container element.
  * @param {Element} main The container element
  */
@@ -470,6 +430,85 @@ export function getLocale(url) {
     return locale;
   }
   return 'us';
+}
+
+function getJapaneseTextCharacterCount(text) {
+  const headingEngCharsRegEx = /[a-zA-Z0-9 ]+/gm;
+  const matches = text.matchAll(headingEngCharsRegEx);
+  const eCnt = [...matches].map((m) => m[0]).reduce((cnt, m) => cnt + m.length, 0);
+  const jtext = text.replaceAll(headingEngCharsRegEx, '');
+  const jCnt = jtext.length;
+  return eCnt * 0.57 + jCnt;
+}
+
+export function addHeaderSizing($block, classPrefix = 'heading', selector = 'h1, h2') {
+  const headings = $block.querySelectorAll(selector);
+  // Each threshold of JP should be smaller than other languages
+  // because JP characters are larger and JP sentences are longer
+  const sizes = getLocale(window.location) === 'jp'
+    ? [
+      { name: 'long', threshold: 8 },
+      { name: 'very-long', threshold: 11 },
+      { name: 'x-long', threshold: 15 },
+    ]
+    : [
+      { name: 'long', threshold: 30 },
+      { name: 'very-long', threshold: 40 },
+      { name: 'x-long', threshold: 50 },
+    ];
+  headings.forEach((h) => {
+    const length = getLocale(window.location) === 'jp'
+      ? getJapaneseTextCharacterCount(h.textContent)
+      : h.textContent.length;
+    // const { length } = h.textContent;
+    sizes.forEach((size) => {
+      if (length >= size.threshold) h.classList.add(`${classPrefix}-${size.name}`);
+    });
+  });
+}
+
+/**
+ * Decorates all sections in a container element.
+ * @param {Element} $main The container element
+ */
+export function decorateSections($main) {
+  $main.querySelectorAll(':scope > div').forEach((section) => {
+    const wrappers = [];
+    let defaultContent = false;
+    [...section.children].forEach((e) => {
+      if (e.tagName === 'DIV' || !defaultContent) {
+        const wrapper = document.createElement('div');
+        wrappers.push(wrapper);
+        defaultContent = e.tagName !== 'DIV';
+        if (defaultContent) wrapper.classList.add('default-content-wrapper');
+      }
+      wrappers[wrappers.length - 1].append(e);
+      const isBlog = document.body.classList.contains('blog');
+      if (getLocale(window.location) === 'jp' && !isBlog && defaultContent) {
+        addHeaderSizing(wrappers[wrappers.length - 1], undefined, 'h1, :first-child:is(h2), :not(h1) ~ :is(h2)');
+      }
+    });
+    wrappers.forEach((wrapper) => section.append(wrapper));
+    section.classList.add('section', 'section-wrapper'); // keep .section-wrapper for compatibility
+    section.setAttribute('data-section-status', 'initialized');
+
+    /* process section metadata */
+    const sectionMeta = section.querySelector('div.section-metadata');
+    if (sectionMeta) {
+      const meta = readBlockConfig(sectionMeta);
+      const keys = Object.keys(meta);
+      keys.forEach((key) => {
+        if (key === 'style') {
+          section.classList.add(toClassName(meta.style));
+        } else if (key === 'anchor') {
+          section.id = toClassName(meta.anchor);
+        } else {
+          section.dataset[key] = meta[key];
+        }
+      });
+      sectionMeta.remove();
+    }
+  });
 }
 
 function getCookie(cname) {
@@ -2044,41 +2083,6 @@ export function trackBranchParameters($links) {
       }
     });
   }
-}
-
-function getJapaneseTextCharacterCount(text) {
-  const headingEngCharsRegEx = /[a-zA-Z0-9 ]+/gm;
-  const matches = text.matchAll(headingEngCharsRegEx);
-  const eCnt = [...matches].map((m) => m[0]).reduce((cnt, m) => cnt + m.length, 0);
-  const jtext = text.replaceAll(headingEngCharsRegEx, '');
-  const jCnt = jtext.length;
-  return eCnt * 0.57 + jCnt;
-}
-
-export function addHeaderSizing($block, classPrefix = 'heading') {
-  const headings = $block.querySelectorAll('h1, h2');
-  // Each threshold of JP should be smaller than other languages
-  // because JP characters are larger and JP sentences are longer
-  const sizes = getLocale(window.location) === 'jp'
-    ? [
-      { name: 'long', threshold: 8 },
-      { name: 'very-long', threshold: 11 },
-      { name: 'x-long', threshold: 15 },
-    ]
-    : [
-      { name: 'long', threshold: 30 },
-      { name: 'very-long', threshold: 40 },
-      { name: 'x-long', threshold: 50 },
-    ];
-  headings.forEach((h) => {
-    const length = getLocale(window.location) === 'jp'
-      ? getJapaneseTextCharacterCount(h.textContent)
-      : h.textContent.length;
-    // const { length } = h.textContent;
-    sizes.forEach((size) => {
-      if (length >= size.threshold) h.classList.add(`${classPrefix}-${size.name}`);
-    });
-  });
 }
 
 if (window.name.includes('performance')) registerPerformanceLogger();

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -426,9 +426,9 @@ function addHeaderSizing($block) {
   // because JP characters are larger and JP sentences are longer
   const sizes = getLocale(window.location) === 'jp'
     ? [
-      { name: 'long', threshold: 10 },
-      { name: 'very-long', threshold: 12 },
-      { name: 'x-long', threshold: 16 },
+      { name: 'long', threshold: 8 },
+      { name: 'very-long', threshold: 11 },
+      { name: 'x-long', threshold: 15 },
     ]
     : [
       { name: 'long', threshold: 30 },

--- a/express/styles/blog.css
+++ b/express/styles/blog.css
@@ -62,9 +62,6 @@
   
   .blog main .hero .blog-header h1 {
     text-align: left;
-  }
-  
-  not:lang(ja).blog main .hero .blog-header h1 {
     font-size: var(--heading-font-size-l);
   }
   
@@ -119,13 +116,14 @@
   }
   
   .blog main .section h3 {
+    font-size: 36px;
     line-height: 40px;
     margin-top: 64px;
     text-align: left;
   }
   
-  not:lang(ja).blog main .section h3 {
-    font-size: 36px;
+  :lang(ja).blog main .section h3 {
+    font-size: var(--heading-font-size-m);
   }
   
   .blog main .section h4 {

--- a/express/styles/blog.css
+++ b/express/styles/blog.css
@@ -122,10 +122,6 @@
     text-align: left;
   }
   
-  :lang(ja).blog main .section h3 {
-    font-size: var(--heading-font-size-m);
-  }
-  
   .blog main .section h4 {
     text-align: left;
   }
@@ -182,3 +178,7 @@
     }
 }
   
+/* Japanese font sizing styles */
+:lang(ja).blog main .section h3 {
+  font-size: var(--heading-font-size-m);
+}

--- a/express/styles/blog.css
+++ b/express/styles/blog.css
@@ -62,6 +62,9 @@
   
   .blog main .hero .blog-header h1 {
     text-align: left;
+  }
+  
+  not:lang(ja).blog main .hero .blog-header h1 {
     font-size: var(--heading-font-size-l);
   }
   
@@ -116,10 +119,13 @@
   }
   
   .blog main .section h3 {
-    font-size: 36px;
     line-height: 40px;
     margin-top: 64px;
     text-align: left;
+  }
+  
+  not:lang(ja).blog main .section h3 {
+    font-size: 36px;
   }
   
   .blog main .section h4 {

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -405,8 +405,32 @@ main h1 {
   font-size: var(--heading-font-size-xxl);
 }
 
+main h1.heading-long {
+  font-size: var(--heading-font-size-xl);
+}
+
+main h1.heading-very-long {
+  font-size: var(--heading-font-size-l);
+}
+
+main h1.heading-x-long {
+  font-size: var(--heading-font-size-m);
+}
+
 main h2 {
   font-size: var(--heading-font-size-l);
+}
+
+main h2.heading-long {
+  font-size: var(--heading-font-size-m);
+}
+
+main h2.heading-very-long {
+  font-size: var(--heading-font-size-m);
+}
+
+main h2.heading-x-long {
+  font-size: var(--heading-font-size-m);
 }
 
 main h3 {

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -929,12 +929,20 @@ main .section[data-section-status='initialized'] {
   font-size: var(--heading-font-size-l);
 }
 
+:lang(ja) main h2.heading-x-long {
+  font-size: var(--heading-font-size-m);
+}
+
 @media (max-width: 600px) {
+  :lang(ja) main h2.heading-long {
+    font-size: var(--heading-font-size-l);
+  }
+
   :lang(ja) main h2.heading-very-long {
     font-size: var(--heading-font-size-m);
   }
-}
 
-:lang(ja) main h2.heading-x-long {
-  font-size: var(--heading-font-size-m);
+  :lang(ja) main h2.heading-x-long {
+    font-size: var(--heading-font-size-m);
+  }
 }

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -414,7 +414,7 @@ main h1 {
 }
 
 :lang(ja) main h1.heading-x-long {
-  font-size: var(--heading-font-size-m);
+  font-size: var(--heading-font-size-l);
 }
 
 main h2 {
@@ -422,11 +422,17 @@ main h2 {
 }
 
 :lang(ja) main h2.heading-long {
-  font-size: var(--heading-font-size-m);
+  font-size: var(--heading-font-size-l);
 }
 
 :lang(ja) main h2.heading-very-long {
-  font-size: var(--heading-font-size-m);
+  font-size: var(--heading-font-size-l);
+}
+
+@media (max-width: 600px) {
+  :lang(ja) main h2.heading-very-long {
+    font-size: var(--heading-font-size-m);
+  }
 }
 
 :lang(ja) main h2.heading-x-long {

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -405,15 +405,15 @@ main h1 {
   font-size: var(--heading-font-size-xxl);
 }
 
-main h1.heading-long {
+:lang(ja) main h1.heading-long {
   font-size: var(--heading-font-size-xl);
 }
 
-main h1.heading-very-long {
+:lang(ja) main h1.heading-very-long {
   font-size: var(--heading-font-size-l);
 }
 
-main h1.heading-x-long {
+:lang(ja) main h1.heading-x-long {
   font-size: var(--heading-font-size-m);
 }
 
@@ -421,15 +421,15 @@ main h2 {
   font-size: var(--heading-font-size-l);
 }
 
-main h2.heading-long {
+:lang(ja) main h2.heading-long {
   font-size: var(--heading-font-size-m);
 }
 
-main h2.heading-very-long {
+:lang(ja) main h2.heading-very-long {
   font-size: var(--heading-font-size-m);
 }
 
-main h2.heading-x-long {
+:lang(ja) main h2.heading-x-long {
   font-size: var(--heading-font-size-m);
 }
 

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -405,38 +405,8 @@ main h1 {
   font-size: var(--heading-font-size-xxl);
 }
 
-:lang(ja) main h1.heading-long {
-  font-size: var(--heading-font-size-xl);
-}
-
-:lang(ja) main h1.heading-very-long {
-  font-size: var(--heading-font-size-l);
-}
-
-:lang(ja) main h1.heading-x-long {
-  font-size: var(--heading-font-size-l);
-}
-
 main h2 {
   font-size: var(--heading-font-size-l);
-}
-
-:lang(ja) main h2.heading-long {
-  font-size: var(--heading-font-size-l);
-}
-
-:lang(ja) main h2.heading-very-long {
-  font-size: var(--heading-font-size-l);
-}
-
-@media (max-width: 600px) {
-  :lang(ja) main h2.heading-very-long {
-    font-size: var(--heading-font-size-m);
-  }
-}
-
-:lang(ja) main h2.heading-x-long {
-  font-size: var(--heading-font-size-m);
 }
 
 main h3 {
@@ -936,4 +906,35 @@ wbr.wbr-off {
 main .section[data-section-status='loading'],
 main .section[data-section-status='initialized'] {
   display: none;
+}
+
+/* Japanese font sizing styles */
+:lang(ja) main h1.heading-long {
+  font-size: var(--heading-font-size-xl);
+}
+
+:lang(ja) main h1.heading-very-long {
+  font-size: var(--heading-font-size-l);
+}
+
+:lang(ja) main h1.heading-x-long {
+  font-size: var(--heading-font-size-l);
+}
+
+:lang(ja) main h2.heading-long {
+  font-size: var(--heading-font-size-l);
+}
+
+:lang(ja) main h2.heading-very-long {
+  font-size: var(--heading-font-size-l);
+}
+
+@media (max-width: 600px) {
+  :lang(ja) main h2.heading-very-long {
+    font-size: var(--heading-font-size-m);
+  }
+}
+
+:lang(ja) main h2.heading-x-long {
+  font-size: var(--heading-font-size-m);
 }


### PR DESCRIPTION
# Japanese font size adjustment for headings
## Background

Japanese fonts look visually bigger than English fonts on web pages if they are both specified with the same pixel size.
CCX website does not have specific font sizing CSS styles for localized pages. Hence for the purpose of better page layout on Japanese pages, some font size adjustments are needed.

## Scope of font size adjustment

Main headings (H1 and H2 HTML tags) are the targets for this adjustment.

## Methodology

CCX website has implemented a character count based logic to dynamically change headings' font sizes, which we can leverage to adjust Japanese page font sizes. The logic works in the following way:

- Define a set of different heading font sizes using CSS variables. E.g., `--heading-font-size-xxxl`, `--heading-font-size-m`, `--heading-font-size-s`, etc. The exact font size values are set differently for different screen sized via media queries.
- Define a set of different CSS classes using those CSS variables. E.g., 
    ```CSS
    main .columns h1.columns-heading-long {
      font-size: var(--heading-font-size-xl);
    }
    ```
- In page loading JS logic, iterate through all H1 and H2 tags, for each tag, count the characters, then set corresponding CSS classes based on character counts. E.g.,
  - If character count is greater than 20, set CSS class: `columns-heading-long`

The above logic has been applied to Column block components on the website. So in this adjustment, we just need to refactor the logic and apply it to wider range components on the site.

## Specifications
### Scope of web page components for adjustment

The following web page components are within the scope of this font size adjustment.

- Column block
- Hero-animation block
- Default content block in each section block on all pages other than blog pages (by CSS selector: `body:not(.blog) .section .default-content-wrapper`)

### Thresholds of character counts

The following thresholds are current applied to select corresponding CSS classes for Japanese headings.

| Character count | CSS class suffix |
|-----------------|------------------|
| 1 - 7           | N/A              |
| 8 - 10          | long             |
| 11 - 14         | very-long        |
| 15+             | x-long           |

**Note:** For headings with a mix of Japanese and English, English character counts are multiplied by a coefficient before being added to Japanese character count. This is because that English characters are usually narrower than Japanese ones. Hence to get more accurate character counts for font sizing, English character counts are "converted" to Japanese counts via the multiplication. The current value of that coefficient is set to 0.57, which is an empirical value from some tests.

## Caveats

The character count based logic applies CSS class names to individual HTML tags and hence can result in inconsistent font sizes for the same level headings on the same page.


Test URLs:
- Before: https://main--express-website--adobe.hlx.page/jp/express/?lighthouse=on
- After: https://jpn-font-sizing--express-website--masonpinz.hlx.page/jp/express/?lighthouse=on
