### PR TITLE
carousel & template-list analytics fix

### DIFF
--- a/express/blocks/shared/carousel.js
+++ b/express/blocks/shared/carousel.js
@@ -131,7 +131,19 @@ export function buildCarousel(selector = ':scope > *', $parent, infinityScrollEn
   const infinityScroll = ($children) => {
     const duplicateContent = () => {
       $children.forEach(($child) => {
-        $platform.append($child.cloneNode(true));
+        const $duplicate = $child.cloneNode(true);
+        const $duplicateLinks = $duplicate.querySelectorAll('a');
+        $platform.append($duplicate);
+
+        if ($duplicate.tagName.toLowerCase() === 'a') {
+          const linksPopulated = new CustomEvent('linkspopulated', { detail: [$duplicate] });
+          document.dispatchEvent(linksPopulated);
+        }
+
+        if ($duplicateLinks) {
+          const linksPopulated = new CustomEvent('linkspopulated', { detail: $duplicateLinks });
+          document.dispatchEvent(linksPopulated);
+        }
       });
     };
     // Duplicate children to simulate smooth scrolling

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -304,7 +304,7 @@ export default async function decorate($block) {
   await decorateTemplateList($block);
   if ($block.classList.contains('horizontal')) {
     /* carousel */
-    await buildCarousel(':scope > .template', $block, true);
+    buildCarousel(':scope > .template', $block, true);
   } else {
     addAnimationToggle($block);
   }

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -71,12 +71,6 @@ export function createOptimizedPicture(src, alt = '', eager = false, breakpoints
   return picture;
 }
 
-function textToName(text) {
-  const splits = text.toLowerCase().split(' ');
-  const camelCase = splits.map((s, i) => (i ? s.charAt(0).toUpperCase() + s.substr(1) : s)).join('');
-  return (camelCase);
-}
-
 async function fetchBlueprint(pathname) {
   if (window.spark.$blueprint) {
     return (window.spark.$blueprint);

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -77,54 +77,6 @@ function textToName(text) {
   return (camelCase);
 }
 
-function trackTemplateClick($a) {
-  /* eslint-disable no-underscore-dangle */
-  /* global digitalData _satellite */
-  let adobeEventName = 'adobe.com:express:cta:';
-  let sparkEventName;
-  const $templateContainer = $a.closest('.template-list');
-  let $cardContainer;
-  let $img;
-  let alt;
-
-  // Template button click
-  if ($templateContainer) {
-    adobeEventName += 'template:';
-
-    $cardContainer = $a.closest('.template-list > div');
-    $img = $cardContainer && $cardContainer.querySelector('img');
-    alt = $img && $img.getAttribute('alt');
-
-    // try to get the image alternate text
-    if ($a.classList.contains('placeholder')) {
-      adobeEventName += 'createFromScratch';
-    } else if (alt) {
-      adobeEventName += textToName(alt);
-    } else {
-      adobeEventName += 'Click';
-    }
-    const w = window.location.href;
-
-    sparkEventName = 'landing:templatePressed';
-
-    if (w.includes('/express-your-fandom')) {
-      const $templates = document.querySelectorAll('a.template');
-      const templateIndex = Array.from($templates).indexOf($a) + 1;
-      sparkEventName += `:${templateIndex}`;
-    }
-
-    digitalData._set('primaryEvent.eventInfo.eventName', adobeEventName);
-    digitalData._set('spark.eventData.eventName', sparkEventName);
-
-    _satellite.track('event', {
-      digitalData: digitalData._snapshot(),
-    });
-
-    digitalData._delete('primaryEvent.eventInfo.eventName');
-    digitalData._delete('spark.eventData.eventName');
-  }
-}
-
 async function fetchBlueprint(pathname) {
   if (window.spark.$blueprint) {
     return (window.spark.$blueprint);
@@ -249,10 +201,6 @@ export async function decorateTemplateList($block) {
       $tmplt = $a;
       $block.append($a);
 
-      $a.addEventListener('click', () => {
-        trackTemplateClick($a);
-      });
-
       // convert A to SPAN
       const $newLink = createTag('span', { class: 'template-link' });
       $newLink.append($link.textContent);
@@ -352,13 +300,17 @@ export async function decorateTemplateList($block) {
       $block.classList.add('template-list-complete');
     }
   }
+
+  const $templateLinks = $block.querySelectorAll('a.template');
+  const linksPopulated = new CustomEvent('linkspopulated', { detail: $templateLinks });
+  document.dispatchEvent(linksPopulated);
 }
 
 export default async function decorate($block) {
   await decorateTemplateList($block);
   if ($block.classList.contains('horizontal')) {
     /* carousel */
-    buildCarousel(':scope > .template', $block, true);
+    await buildCarousel(':scope > .template', $block, true);
   } else {
     addAnimationToggle($block);
   }

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -509,16 +509,19 @@ loadScript(martechURL, () => {
       const $img = $cardContainer && $cardContainer.querySelector('img');
       const alt = $img && $img.getAttribute('alt');
 
+      sparkEventName = 'landing:templatePressed';
+
       // try to get the image alternate text
-      if ($a.classList.contains('placeholder')) {
+      if ($a.classList.contains('template-title-link')) {
+        adobeEventName += 'viewAll';
+        sparkEventName = 'landing:templateViewAllPressed';
+      } else if ($a.classList.contains('placeholder')) {
         adobeEventName += 'createFromScratch';
       } else if (alt) {
         adobeEventName += textToName(alt);
       } else {
         adobeEventName += 'Click';
       }
-
-      sparkEventName = 'landing:templatePressed';
 
       if (w.location.href.includes('/express-your-fandom')) {
         const $templates = document.querySelectorAll('a.template');

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -504,12 +504,9 @@ loadScript(martechURL, () => {
     // Template button click
     if ($templateContainer) {
       adobeEventName += 'template:';
-
-      const $cardContainer = $a.closest('.template-list > div');
-      const $img = $cardContainer && $cardContainer.querySelector('img');
-      const alt = $img && $img.getAttribute('alt');
-
       sparkEventName = 'landing:templatePressed';
+
+      const $img = $a.querySelector('img');
 
       // try to get the image alternate text
       if ($a.classList.contains('template-title-link')) {
@@ -517,8 +514,8 @@ loadScript(martechURL, () => {
         sparkEventName = 'landing:templateViewAllPressed';
       } else if ($a.classList.contains('placeholder')) {
         adobeEventName += 'createFromScratch';
-      } else if (alt) {
-        adobeEventName += textToName(alt);
+      } else if ($img && $img.alt) {
+        adobeEventName += textToName($img.alt);
       } else {
         adobeEventName += 'Click';
       }

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -501,12 +501,30 @@ loadScript(martechURL, () => {
     const $templateContainer = $a.closest('.template-list');
     const $tutorialContainer = $a.closest('.tutorial-card');
     // let cardPosition;
-
     // Template button click
     if ($templateContainer) {
-      // This behaviour was moved to the template-list.js
-      // This return statement prevents a double binding.
-      return;
+      adobeEventName += 'template:';
+
+      const $cardContainer = $a.closest('.template-list > div');
+      const $img = $cardContainer && $cardContainer.querySelector('img');
+      const alt = $img && $img.getAttribute('alt');
+
+      // try to get the image alternate text
+      if ($a.classList.contains('placeholder')) {
+        adobeEventName += 'createFromScratch';
+      } else if (alt) {
+        adobeEventName += textToName(alt);
+      } else {
+        adobeEventName += 'Click';
+      }
+
+      sparkEventName = 'landing:templatePressed';
+
+      if (w.location.href.includes('/express-your-fandom')) {
+        const $templates = document.querySelectorAll('a.template');
+        const templateIndex = Array.from($templates).indexOf($a) + 1;
+        sparkEventName += `:${templateIndex}`;
+      }
       // Button in the FAQ
     } else if ($tutorialContainer) {
       const videoName = textToName($a.querySelector('h3').textContent);


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

No JIRA issue provided for this fix.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/drafts/rofe/intent-driven-home
- After: https://template-tracking--express-website--webistry-development.hlx3.page/drafts/rofe/intent-driven-home

Analytics tracking was not being extended to the carousel duplicated elements. Additionally, I leveraged the new dispatchEvent system in order to return template-list link tracking back to its original place.
