### PR TITLE
fix(template-list): regression from #448

### DIFF
--- a/express/blocks/template-list/template-list.css
+++ b/express/blocks/template-list/template-list.css
@@ -175,7 +175,7 @@ main .template-list.sixcols .template {
 }
 
 main .template-list .template:not(.placeholder) > div:first-of-type {
-  /*overflow: hidden*/;
+  overflow: hidden;
   border-radius: 7px;
   line-height: 0;
 }


### PR DESCRIPTION
#448 tried to fix a safari issue but introduced a regression in the hover state animation for all browsers: 
![image](https://user-images.githubusercontent.com/1609742/175236341-1e7dbc38-4619-4ecc-a9cb-f76e27f690c4.png)

@MarquiseRosier FYI

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/create/flyer
- After: https://revert-448--express-website--adobe.hlx.page/express/create/flyer?lighthouse=on
