### PR TITLE
fix(promotion): hide unprocessed promo block

### DIFF
--- a/express/blocks/promotion/promotion.css
+++ b/express/blocks/promotion/promotion.css
@@ -4,6 +4,10 @@ main .section.promotion-container {
   margin-bottom: 120px;
 }
 
+main .promotion[data-block-status="loaded"] {
+  display: block;
+}
+
 main .promotion .promotion-wrapper {
   border: 1px solid var(--color-gray-300);
   border-radius: 8px;

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -812,6 +812,11 @@ img.icon-apple-store, img.icon-google-store, img.icon-galaxy-store, img.icon-mic
   height: 32px;
 }
 
+/* hide promotion block until loaded */
+main .promotion {
+  display: none;
+}
+
 /* hide floating button before css loads */
 main .floating-button-wrapper,
 main .floating-button {


### PR DESCRIPTION
Sometimes you can see an `illustrator` text flashing at the top of the page, which likely stems from the promotion block's unprocessed content. This change ensures that the block stays hidden until fully loaded.

Test URLs:
- Before: https://main--express-website--adobe.hlx.live/express/create/flyer
- After: https://promo-flash--express-website--adobe.hlx.live/express/create/flyer?lighthouse=on