### PR TITLE
fix(promotion): regression in auto-block code

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -975,7 +975,7 @@ function addPromotion() {
       };
       // insert promotion at the bottom
       if (promos[category]) {
-        const $promoSection = createTag('div', { class: '.section' });
+        const $promoSection = createTag('div', { class: 'section' });
         $promoSection.innerHTML = `<div class="promotion" data-block-name="promotion"><div><div>${promos[category]}</div></div></div>`;
         document.querySelector('main').append($promoSection);
         loadBlock($promoSection.querySelector(':scope .promotion'));


### PR DESCRIPTION
When promotion blocks are inserted automatically, the section has class `.section` instead of `section` which causes the block to be rendered with the full window width. This is a regression from #433.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/create/logo
- After: https://promo-regression--express-website--adobe.hlx.page/express/create/logo?lighthouse=on
