### PR TITLE
[MWPW-112381] free plan widget

### DIFF
--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -18,6 +18,7 @@ import {
   toClassName,
   getLocale,
   getIconElement,
+  addFreePlanWidget,
 } from '../../scripts/scripts.js';
 
 import {
@@ -275,6 +276,11 @@ export default function decorate($block) {
         }
       });
     }
+  }
+
+  // add free plan widget to first columns block on every page
+  if (document.querySelector('main .columns') === $block) {
+    addFreePlanWidget($block.querySelector(':scope .column:not(.hero-animation-overlay,.columns-picture)'));
   }
 
   // invert buttons in regular columns inside columns-highlight-container

--- a/express/blocks/hero-animation/hero-animation.css
+++ b/express/blocks/hero-animation/hero-animation.css
@@ -327,7 +327,7 @@ main .hero-animation .free-plan-widget {
 }
 
 main .hero-animation .free-plan-widget > ul {
-  justify-content: left;
+  align-items: unset;
 }
 
 main .hero-animation .free-plan-widget > ul > li {

--- a/express/blocks/hero-animation/hero-animation.css
+++ b/express/blocks/hero-animation/hero-animation.css
@@ -318,3 +318,24 @@ main .hero-animation .hero-shadow picture {
     transform: translate(-15%, -2px);
   }
 }
+
+/* free plan widget */
+main .hero-animation .free-plan-widget {
+  background-color: transparent;
+  margin: 0;
+  padding: 10px 0;
+}
+
+main .hero-animation .free-plan-widget > ul {
+  justify-content: left;
+}
+
+main .hero-animation .free-plan-widget > ul > li {
+  font-size: var(--body-font-size-m);
+  padding-left: 0;
+
+}
+
+main .hero-animation .free-plan-widget > p {
+  display: none;
+}

--- a/express/blocks/hero-animation/hero-animation.js
+++ b/express/blocks/hero-animation/hero-animation.js
@@ -12,6 +12,7 @@
 
 import {
   addAnimationToggle,
+  addFreePlanWidget,
   createTag,
   toClassName,
 // eslint-disable-next-line import/no-unresolved
@@ -242,6 +243,7 @@ export default async function decorate($block) {
       if (videoLink) {
         transformToVideoLink($div, videoLink);
       }
+      addFreePlanWidget($div.children[0]);
     }
 
     // timecode animations

--- a/express/blocks/make-a-project/make-a-project.css
+++ b/express/blocks/make-a-project/make-a-project.css
@@ -11,7 +11,6 @@ main .section.make-a-project-container > div {
 }
 
 main .make-a-project {
-  max-height: 502px;
   display: flex;
   flex-direction: column;
 }
@@ -457,4 +456,13 @@ main .hero-animation-wide-container .hero-animation-wrapper + .make-a-project-wr
 
 main .hero-animation-wide-container .hero-animation-wrapper + .make-a-project-wrapper .make-a-project-item:nth-child(7) img {
   max-height: 158px;
+}
+
+/* free plan widget */
+main .make-a-project .free-plan-widget {
+  background-color: var(--color-white);
+}
+
+main .make-a-project .free-plan-widget > p {
+  display: none;
 }

--- a/express/blocks/make-a-project/make-a-project.css
+++ b/express/blocks/make-a-project/make-a-project.css
@@ -461,6 +461,12 @@ main .hero-animation-wide-container .hero-animation-wrapper + .make-a-project-wr
 /* free plan widget */
 main .make-a-project .free-plan-widget {
   background-color: var(--color-white);
+  margin: 0;
+  padding: 10px 0;
+}
+
+main .make-a-project .free-plan-widget > ul {
+  align-items: unset;
 }
 
 main .make-a-project .free-plan-widget > p {

--- a/express/blocks/make-a-project/make-a-project.js
+++ b/express/blocks/make-a-project/make-a-project.js
@@ -12,6 +12,7 @@
 
 import {
   createTag,
+  addFreePlanWidget,
 } from '../../scripts/scripts.js';
 
 import { buildCarousel } from '../shared/carousel.js';
@@ -73,6 +74,7 @@ export default function decorate($block) {
         $projectlist.appendChild($row);
       } else {
         $row.classList.add('make-a-project-description');
+        addFreePlanWidget($row.firstElementChild);
       }
     });
     if ($projectlist.children.length) {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1900,6 +1900,19 @@ function removeMetadata() {
   });
 }
 
+export async function addFreePlanWidget(elem) {
+  if (elem && getMetadata('show-free-plan')) {
+    const placeholders = await fetchPlaceholders();
+    const widget = createTag('div', { class: 'free-plan-widget' });
+    widget.innerHTML = `<ul>
+      <li>${placeholders['free-plan-check-1']}</li>
+      <li>${placeholders['free-plan-check-2']}</li>
+    </ul>
+    <p>${placeholders['free-plan-description']}</p>`;
+    elem.append(widget);
+  }
+}
+
 /**
  * loads everything that doesn't need to be delayed.
  */

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -775,6 +775,63 @@ main .columns.columns-marquee {
   min-height: 650px;
 }
 
+/* free plan widget */
+main .block .free-plan-widget {
+  background-color: var(--color-gray-100);
+  border-radius: 10px;
+  margin: 20px 0 0;
+  padding: 0;
+}
+
+main .block .free-plan-widget > ul {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  margin: 0;
+}
+
+main .block .free-plan-widget > ul > li {
+  display: flex;
+  flex-direction: row;
+  max-width: unset;
+  padding: 10px 0;
+  font-size: var(--body-font-size-m);
+  font-weight: 600;
+}
+
+main .block .free-plan-widget > ul > li::before {
+  content: " ";
+  background: green;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  float: none;
+  margin: 1px 6px 0 0;
+}
+
+main .section .free-plan-widget > p {
+  font-size: var(--body-font-size-s);
+  margin: 0;
+}
+
+@media (min-width: 600px) {
+  main .block .free-plan-widget {
+    max-width: 498px;
+    margin: 40px auto 0;
+    padding: 20px;
+  }  
+
+  main .block .free-plan-widget > ul {
+    justify-content: center;
+    flex-direction: row;
+  }
+
+  main .block .free-plan-widget > ul > li {
+    padding: 10px;
+    font-size: var(--body-font-size-l);
+  }
+}
+
 @media (min-width: 1200px) {
   main .template-list-fourcols-container > div,
   main .template-list-horizontal-container > div {

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -777,26 +777,30 @@ main .columns.columns-marquee {
 
 /* free plan widget */
 main .block .free-plan-widget {
+  box-sizing: border-box;
   background-color: var(--color-gray-100);
   border-radius: 10px;
   margin: 20px 0 0;
-  padding: 0;
+  padding: 20px;
 }
 
 main .block .free-plan-widget > ul {
   display: flex;
   flex-direction: column;
+  align-items: center;
   padding: 0;
   margin: 0;
 }
 
 main .block .free-plan-widget > ul > li {
   display: flex;
+  width: fit-content;
   flex-direction: row;
   max-width: unset;
   padding: 10px 0;
   font-size: var(--body-font-size-m);
   font-weight: 600;
+  white-space: nowrap;
 }
 
 main .block .free-plan-widget > ul > li::before {
@@ -818,7 +822,6 @@ main .section .free-plan-widget > p {
   main .block .free-plan-widget {
     max-width: 498px;
     margin: 40px auto 0;
-    padding: 20px;
   }  
 
   main .block .free-plan-widget > ul {

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -782,6 +782,7 @@ main .block .free-plan-widget {
   border-radius: 10px;
   margin: 20px 0 0;
   padding: 20px;
+  width: 322px;
 }
 
 main .block .free-plan-widget > ul {
@@ -820,7 +821,7 @@ main .section .free-plan-widget > p {
 
 @media (min-width: 600px) {
   main .block .free-plan-widget {
-    max-width: 498px;
+    width: 498px;
     margin: 40px auto 0;
   }  
 


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://jira.corp.adobe.com/browse/MWPW-112381

The free plan widget can be enabled on pages with `hero-animation`, `make-a-project` or `columns` blocks by adding `show-free-plan` to the metadata.

Test URLs:
- [Homepage](https://mwpw-112381--express-website--adobe.hlx.page/drafts/rofe/intent-driven-home?lighthouse=on)
- [Landing page](https://mwpw-112381--express-website--adobe.hlx.page/drafts/rofe/video?lighthouse=on)
