### PR TITLE
fix(puf): bold text-stroke-color of "Save 17%" text node

### DIFF
--- a/express/blocks/puf/puf.css
+++ b/express/blocks/puf/puf.css
@@ -330,7 +330,9 @@ main .puf .puf-right {
         -webkit-mask-image: url('/express/blocks/puf/check.svg');
         mask-image: url('/express/blocks/puf/check.svg');
         -webkit-mask-repeat: no-repeat;
-        -webkit-mask-size: 100% auto;
+        -webkit-mask-size: contain;
+        mask-position: center;
+        mask-size: contain;
     }
 }
 

--- a/express/blocks/puf/puf.css
+++ b/express/blocks/puf/puf.css
@@ -118,7 +118,11 @@ main .block.puf .puf-card .puf-card-top .puf-card-plans > div span {
 
 main .block.puf .puf-card .puf-card-top .puf-card-plans > div.strong {
     -webkit-text-stroke-width: .6px;
-    -webkit-text-stroke-color: black;
+    -webkit-text-stroke-color: #5C5CE0;
+}
+
+main .block.puf .puf-card .puf-card-top .puf-card-plans > div.strong span {
+  -webkit-text-stroke-color: black;
 }
 
 main .block.puf .puf-card .puf-card-top .puf-card-switch {

--- a/express/blocks/puf/puf.css
+++ b/express/blocks/puf/puf.css
@@ -331,6 +331,7 @@ main .puf .puf-right {
         mask-image: url('/express/blocks/puf/check.svg');
         -webkit-mask-repeat: no-repeat;
         -webkit-mask-size: contain;
+        mask-repeat: no-repeat;
         mask-position: center;
         mask-size: contain;
     }

--- a/express/blocks/puf/puf.css
+++ b/express/blocks/puf/puf.css
@@ -330,6 +330,7 @@ main .puf .puf-right {
         -webkit-mask-image: url('/express/blocks/puf/check.svg');
         mask-image: url('/express/blocks/puf/check.svg');
         -webkit-mask-repeat: no-repeat;
+        -webkit-mask-position: center;
         -webkit-mask-size: contain;
         mask-repeat: no-repeat;
         mask-position: center;


### PR DESCRIPTION
Fix 2 small issues -> {
`bold text-stroke-color of "Save 17%" #text node`
`checkmark being cut off at the bottom`
}
<img width="162" alt="image" src="https://user-images.githubusercontent.com/62023521/176860789-44ca3a41-c65e-4f75-a9a1-da7e16e0a49b.png">
<img width="54" alt="image" src="https://user-images.githubusercontent.com/62023521/176860852-2e73726e-e4d6-47dd-bf7d-e4b54e74c588.png">

Test URLs:
- Before: https://mwpw-111453--express-website--adobe.hlx.page/drafts/williambsm/pricing-new
- After: https://mwpw-111453-bold-color--express-website--webistry-development.hlx.page/drafts/williambsm/pricing-new
