### PR TITLE
feat: allow legal copy anywhere

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -56,11 +56,6 @@ main .columns p.powered-by {
   line-height: 1.2;
 }
 
-main .columns p.legal-copy {
-  font-size: var(--body-font-size-xs);
-  line-height: 1.5;
-}
-
 main .columns p.button-container {
   margin: 0;
   margin-top: 40px;

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -175,14 +175,6 @@ export default function decorate($block) {
         $parentDiv.insertBefore($pics[0], $parentParagraph);
       }
 
-      // legal copy
-      $cell.querySelectorAll(':scope p').forEach(($p) => {
-        const pText = $p.textContent.trim();
-        if (['*', '†'].includes(pText.charAt(0))) {
-          $p.classList.add('legal-copy');
-        }
-      });
-
       // this probably needs to be tighter and possibly earlier
       const $a = $cell.querySelector('a');
       if ($a) {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1923,6 +1923,20 @@ function addJapaneseSectionHeaderSizing() {
 }
 
 /**
+ * Detects legal copy based on a * or † prefix and applies a smaller font size.
+ * @param {HTMLMainElement} main The main element
+ */
+function decorateLegalCopy(main) {
+  const legalCopyPrefixes = ['*', '†'];
+  main.querySelectorAll('p').forEach(($p) => {
+    const pText = $p.textContent.trim()?.charAt(0);
+    if (pText && legalCopyPrefixes.includes(pText)) {
+      $p.classList.add('legal-copy');
+    }
+  });
+}
+
+/**
  * loads everything needed to get to LCP.
  */
 async function loadEager() {
@@ -1934,6 +1948,7 @@ async function loadEager() {
     await decorateMain(main);
     decorateHeaderAndFooter();
     decoratePageStyle();
+    decorateLegalCopy(main);
     addJapaneseSectionHeaderSizing();
     displayEnv();
     displayOldLinkWarning();

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -606,7 +606,7 @@ main .hero a.button:any-link {
   border-radius: 22px;
 }
 
-main .block p.legal-copy {
+main .section div .block p.legal-copy {
   font-size: var(--body-font-size-xs);
   line-height: 1.5;
 }

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -606,6 +606,10 @@ main .hero a.button:any-link {
   border-radius: 22px;
 }
 
+main .block p.legal-copy {
+  font-size: var(--body-font-size-xs);
+  line-height: 1.5;
+}
 
 @media (min-width:600px) {
   main .hero h5 {


### PR DESCRIPTION
Legal copy (starting with `*` or `† ` and displayed in smaller type) is currently only supported inside columns blocks. We should make it more universal.

Test URLs (see at the bottom of the hero animation):
- Before: https://main--express-website--adobe.hlx.page/drafts/Ankush%20hcl37284/DOTCOM-65253/clasroom-accounts
- After: https://legal-copy--express-website--adobe.hlx.page/drafts/Ankush%20hcl37284/DOTCOM-65253/clasroom-accounts?lighthouse=on
