### PR TITLE
fix(premium-plan): cards cut off on mobile

### DIFF
--- a/express/blocks/premium-plan/premium-plan.css
+++ b/express/blocks/premium-plan/premium-plan.css
@@ -235,6 +235,7 @@ main .premium-plan .premium-plan-card ul li a svg {
   main .premium-plan-cards .carousel-container,
   main .premium-plan-cards .carousel-container .carousel-platform {
     display: block;
+    max-height: unset;
   }
 
   main .premium-plan-cards .carousel-container a.button.carousel-arrow {


### PR DESCRIPTION
Premium plan cards get cut off after first one on mobile.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/pricing
- After: https://premium-plan-fix--express-website--adobe.hlx.page/express/pricing?lighthouse=on
