### PR TITLE
fix(free-plan-widget): broken on regular hero animation

### DIFF
--- a/express/blocks/hero-animation/hero-animation.css
+++ b/express/blocks/hero-animation/hero-animation.css
@@ -338,8 +338,20 @@ main .hero-animation .hero-shadow picture {
 
 /* free plan widget */
 
-main .block .button-container.free-plan-container {
+main .hero-animation .button-container.free-plan-container {
   justify-content: left;
+  align-items: flex-start;
+  flex-direction: column;
+}
+
+main .hero-animation .button-container.free-plan-container .free-plan-widget {
+  margin-top: 40px;
+  color: var(--body-color);
+}
+
+main .hero-animation.wide .button-container.free-plan-container {
+  flex-direction: row;
+  align-items: center;
 }
 
 main .hero-animation.wide .free-plan-widget {


### PR DESCRIPTION
Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/spotlight/explore
- After: - https://free-plan-fix--express-website--adobe.hlx.page/express/spotlight/explore?lighthouse=on

Cross-check if free plan widget still behaves correctly on other pages:
- https://free-plan-fix--express-website--adobe.hlx.page/express/?lighthouse=on
- https://free-plan-fix--express-website--adobe.hlx.page/express/create/flyer?lighthouse=on