### PR TITLE
chore: remove optional chaining

### DIFF
--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -935,7 +935,7 @@ loadScript(martechURL, () => {
 
     if (ecid) {
       w.setAudienceManagerSegments = (json) => {
-        if (json?.segments?.includes(RETURNING_VISITOR_SEGMENT_ID)) {
+        if (json && json.segments && json.segments.includes(RETURNING_VISITOR_SEGMENT_ID)) {
           const audiences = Context.get('audiences');
           const segments = Context.get('segments');
           audiences.push(ENABLE_PRICING_MODAL_AUDIENCE);
@@ -985,7 +985,7 @@ loadScript(martechURL, () => {
           }
         }
 
-        if (json?.segments?.includes(USED_ACTION_SEGMENT_ID)) {
+        if (json && json.segments && json.segments.includes(USED_ACTION_SEGMENT_ID)) {
           const audiences = Context.get('audiences');
           const segments = Context.get('segments');
           audiences.push(ENABLE_RATE_ACTION_AUDIENCE);

--- a/tools/preview/preview.js
+++ b/tools/preview/preview.js
@@ -84,7 +84,7 @@ async function createExperiment() {
       // the query is a bit slow, so I'm only fetching the results when the popup is opened
       const resultsURL = new URL('https://helix-pages.anywhere.run/helix-services/run-query@v2/rum-experiments');
       resultsURL.searchParams.set('experiment', experiment);
-      if (window.hlx.sidekickConfig?.host) {
+      if (window.hlx.sidekickConfig && window.hlx.sidekickConfig.host) {
         // restrict results to the production host, this also reduces query cost
         resultsURL.searchParams.set('domain', window.hlx.sidekickConfig.host);
       }


### PR DESCRIPTION
Remove JS optional chaining which still a JS experimental feature.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/
- After: https://optional-chaining--express-website--adobe.hlx.page/express/
