### PR TITLE
refactor(blocks/blog-posts/blog-posts.css):

### DIFF
--- a/express/blocks/blog-posts/blog-posts.css
+++ b/express/blocks/blog-posts/blog-posts.css
@@ -12,7 +12,6 @@ main .blog-posts-container > div {
 
 .blog main .blog-posts-container > div > h2, main .blog-posts-container div.blog-posts-decoration {
   max-width: 280px;
-  margin: auto;
 }
 
 main .blog-posts-container  div.blog-posts-decoration {

--- a/express/blocks/list/list.css
+++ b/express/blocks/list/list.css
@@ -26,6 +26,10 @@ main .list .item-text {
     line-height: 1.4;
 }
 
+main li, p {
+  line-height: 200%
+}
+
 @media (min-width: 900px) {
   main .list {
    max-width: 600px;


### PR DESCRIPTION
align h2 and p elements

h2 and p groups of elements are misaligned! This ensures everything is neat and also expresses hierarchy via indentation of the h2 and p away from the section that follows so they stand out.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/learn/blog
- After: https://fix-alignment--express-website--adobe.hlx.page/express/learn/blog
