### PR TITLE
fix(PUF): fix icon sizing in PUF block

### DIFF
--- a/express/blocks/puf/puf.css
+++ b/express/blocks/puf/puf.css
@@ -312,7 +312,7 @@ main .puf .puf-right {
         margin-right: 16px;
         width: 44px;
         height: 44px;
-		flex: 0 0 44px
+        flex: 0 0 44px
     }
 
     main .block.puf .puf-card .puf-card-bottom .puf-list-item {

--- a/express/blocks/puf/puf.css
+++ b/express/blocks/puf/puf.css
@@ -312,6 +312,7 @@ main .puf .puf-right {
         margin-right: 16px;
         width: 44px;
         height: 44px;
+		flex: 0 0 44px
     }
 
     main .block.puf .puf-card .puf-card-bottom .puf-list-item {


### PR DESCRIPTION
Fix: issue reported on slack:
![image](https://user-images.githubusercontent.com/62023521/182426313-9be10ab0-3b03-4bff-8bc6-7bbebc663b88.png)

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/it/express/pricing
- After: https://puf-icon-fix--express-website--webistry-development.hlx.page/it/express/pricing?lighthouse=on
