### PR TITLE
fix(branch-io): move modal from behind the banch banner

### DIFF
--- a/express/blocks/branch-io/branch-io.css
+++ b/express/blocks/branch-io/branch-io.css
@@ -1,3 +1,8 @@
 .branch-io {
   display: none;
 }
+
+body.branch-banner-is-active .doMoreBanner,
+body.branch-banner-is-active .doMoreModal { 
+  bottom: 76px; 
+}

--- a/express/blocks/branch-io/branch-io.css
+++ b/express/blocks/branch-io/branch-io.css
@@ -2,7 +2,11 @@
   display: none;
 }
 
-body.branch-banner-is-active .doMoreBanner,
-body.branch-banner-is-active .doMoreModal { 
+body.branch-banner-is-active ~ .doMoreModal {
   bottom: 76px; 
+}
+
+.doMoreModal:not(.doMoreModalHide) ~ body.branch-banner-is-active #branch-banner-iframe,
+.doMoreModal:not(.doMoreModalHide) ~ body .floating-button-wrapper {
+  display: none;
 }


### PR DESCRIPTION
Fix ![image](https://user-images.githubusercontent.com/62023521/184246398-dd445c41-8408-46bd-af64-892925135762.png)

- Before: (mobile-only, click on the floating button at the bottom to open the modal):
https://www.adobe.com/express/spotlight/image/remove-background?at_preview_token=2UkyhYTLG4UVqSs5iw814Q&at_preview_index=1_3&at_preview_listed_activities_only=true&at_preview_evaluate_as_true_audience_ids=2033593
