### PR TITLE
fix(express/styles/blog.css): fix left align

### DIFF
--- a/express/styles/blog.css
+++ b/express/styles/blog.css
@@ -91,18 +91,21 @@
   }
   
   .blog div.section {
-    text-align: left;
+    /*text-align: left;*/
     margin: 0;
   }
   
-  .blog-article div.section > div > p, .blog-article div.section > div > h2,
+  .blog-article div.section > div > p:not(.button-container), .blog-article div.section > div > h2,
   .blog-article div.section > div > h3, .blog-article div.section > div > h4,
   .blog-article div.section > div > h5, .blog-article div.section > div > ul, 
   .blog-article div.section > div > ol, .blog-article div.section > div > .table-of-contents {
     max-width: 530px;
     margin-left: auto;
     margin-right: auto;
+    text-align: left;
   }
+
+
 
   
   .blog div.section.fullwidth > div {


### PR DESCRIPTION
folks have been reporting some weird alignment and its because of this line

This PR just removes the blanket text-align that overrides even button container styling, and specifies what needs to be centered and what needs to be left-aligned.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/fr/express/learn/blog/tips-improve-linkedin-profile
- After: https://fix-general-left-alignment--express-website--adobe.hlx.page/fr/express/learn/blog/tips-improve-linkedin-profile

- Before: https://www.adobe.com/fr/express/learn/blog/design-youtube-banner
- After: https://fix-general-left-alignment--express-website--adobe.hlx.page/fr/express/learn/blog/design-youtube-banner

- Before: https://www.adobe.com/fr/express/learn/blog/design-event-poster#questions-fr%C3%A9quemment-pos%C3%A9es
- After: https://fix-general-left-alignment--express-website--adobe.hlx.page/fr/express/learn/blog/design-event-poster#questions-fr%C3%A9quemment-pos%C3%A9es

- Before: https://main--express-website--adobe.hlx.page/fr/express/learn/blog/how-to-create-email-signature
- After: https://fix-general-left-alignment--express-website--adobe.hlx.page/fr/express/learn/blog/how-to-create-email-signature