### PR TITLE
fix(app-store-blade): fetch ratings from placeholder instead

### DIFF
--- a/express/blocks/app-store-blade/app-store-blade.js
+++ b/express/blocks/app-store-blade/app-store-blade.js
@@ -189,13 +189,13 @@ function decorateBlade($block, payload) {
   decorateRatings($block, payload);
 }
 
-export default function decorate($block) {
+export default async function decorate($block) {
   const payload = {
     heading: '',
     copyParagraphs: [],
     showRating: true,
-    ratingScore: getMetadata('apple-store-rating-score'),
-    ratingCount: getMetadata('apple-store-rating-count'),
+    ratingScore: '',
+    ratingCount: '',
     image: '',
     QRCode: '',
     badgeLink: '',
@@ -203,7 +203,14 @@ export default function decorate($block) {
     other: [],
   };
 
-  if (['yes', 'true', 'on'].includes(getMetadata('show-standard-app-store-blocks').toLowerCase()) && $block.children.length <= 0) {
+  await fetchPlaceholders()
+    .then((placeholders) => {
+      payload.ratingScore = placeholders['apple-store-rating-score'];
+      payload.ratingCount = placeholders['apple-store-rating-count'];
+    });
+
+  if (['yes', 'true', 'on'].includes(getMetadata('show-standard-app-store-blocks')
+    .toLowerCase()) && $block.children.length <= 0) {
     buildStandardPayload($block, payload);
   } else {
     buildPayloadFromBlock($block, payload);


### PR DESCRIPTION
Fix [MWPW-113696](https://jira.corp.adobe.com/browse/MWPW-113696)

Test URLs:
- Before: https://mwpw-113696--express-website--adobe.hlx.page/drafts/qiyundai/create/generic-app-store-blade
- After: 
  - Code generated version: https://mwpw-113696--express-website--webistry-development.hlx.page/drafts/qiyundai/create/generic-app-store-blade
  - Localizable fragment: https://mwpw-113696--express-website--webistry-development.hlx.page/drafts/qiyundai/create/fragment-app-store-blade

MWPW-113319, the mobile version of this block can also be authored using Fragment. It works out of box!