### PR TITLE
fix(app-store-highlight): adding app store blocks to sections to split

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1590,7 +1590,7 @@ function buildAutoBlocks($main) {
 
 function splitSections($main) {
   $main.querySelectorAll(':scope > div > div').forEach(($block) => {
-    const blocksToSplit = ['template-list', 'layouts', 'banner', 'faq', 'promotion', 'fragment'];
+    const blocksToSplit = ['template-list', 'layouts', 'banner', 'faq', 'promotion', 'fragment', 'app-store-highlight', 'app-store-blade'];
 
     if (blocksToSplit.includes($block.className)) {
       unwrapBlock($block);


### PR DESCRIPTION
Fixed MWPW-113319

The issue didn't present itself when being developed on two separate branches. Once merged, the blocks got built into the same section and broke the entire auto blocking process. Adding them to the sections to split fixed the issue.

Test URLs:
- Before: https://main--express-website--webistry-development.hlx.page/drafts/qiyundai/create/app-store-auto-blocks?lighthouse=on
- After: https://mwpw-113319--express-website--webistry-development.hlx.page/drafts/qiyundai/create/app-store-auto-blocks?lighthouse=on
