### PR TITLE
fix(express/styles/blog.css): align p elements

### DIFF
--- a/express/styles/blog.css
+++ b/express/styles/blog.css
@@ -115,7 +115,8 @@
   }
   
   
-  .blog main div.section h2, .blog main div.section h3  {
+  .blog main div.section h2, .blog main div.section h3, 
+  .blog main div.section h2 + p, .blog main div.section h3 + p  {
     text-align: left;
   }
   


### PR DESCRIPTION
p elements are misaligned because of some styling in styles.css, just apply the same styling that happens
to upper sibling in document tree.

- Before: https://www.adobe.com/express/learn/blog
- After: https://fix-view-all-alignment--express-website--adobe.hlx.page/express/learn/blog
