### PR TITLE
More schemas

### DIFF
--- a/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
+++ b/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
@@ -124,7 +124,11 @@ export default function decorate(block) {
   const heading = section.querySelector('h2, h3, h4');
 
   const includeSchema = block.classList.contains('schema');
-
+  if (includeSchema) {
+    // this is due to block loaded setting how-to-steps-carousel-schema-container
+    // and not how-to-steps-carousel-container as expected
+    section.classList.add('how-to-steps-carousel-container');
+  }
   const schema = {
     '@context': 'http://schema.org',
     '@type': 'HowTo',
@@ -204,7 +208,7 @@ export default function decorate(block) {
   if (includeSchema) {
     const $schema = createTag('script', { type: 'application/ld+json' });
     $schema.innerHTML = JSON.stringify(schema);
-    const $head = doc.head;
+    const $head = document.head;
     $head.append($schema);
   }
 

--- a/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
+++ b/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
@@ -121,6 +121,17 @@ export default function decorate(block) {
   const howto = block;
   const rows = Array.from(howto.children);
 
+  const heading = section.querySelector('h2, h3, h4');
+
+  const includeSchema = block.classList.contains('schema');
+
+  const schema = {
+    '@context': 'http://schema.org',
+    '@type': 'HowTo',
+    name: (heading && heading.textContent) || document.title,
+    step: [],
+  };
+
   const numbers = createTag('div', { class: 'tip-numbers', 'aria-role': 'tablist' });
   block.prepend(numbers);
   const tips = createTag('div', { class: 'tips' });
@@ -143,6 +154,16 @@ export default function decorate(block) {
     row.append(text);
 
     tips.prepend(row);
+
+    schema.step.push({
+      '@type': 'HowToStep',
+      position: i + 1,
+      name: h3.textContent,
+      itemListElement: {
+        '@type': 'HowToDirection',
+        text: text.textContent,
+      },
+    });
 
     const number = createTag('div', {
       class: `tip-number tip-${i + 1}`,
@@ -179,6 +200,13 @@ export default function decorate(block) {
       number.classList.add('active');
     }
   });
+
+  if (includeSchema) {
+    const $schema = createTag('script', { type: 'application/ld+json' });
+    $schema.innerHTML = JSON.stringify(schema);
+    const $head = doc.head;
+    $head.append($schema);
+  }
 
   if (window) {
     window.addEventListener('resize', () => {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -803,6 +803,7 @@ const blocksWithOptions = [
   'feature-list',
   'icon-list',
   'table-of-contents',
+  'how-to-steps-carousel',
   'how-to-steps',
   'banner',
   'pricing-columns',
@@ -822,16 +823,20 @@ export function decorateBlock(block) {
     let shortBlockName = blockName;
     block.classList.add('block');
     // begin CCX custom block option class handling
-    if (shortBlockName !== 'how-to-steps-carousel') {
-      blocksWithOptions.forEach((b) => {
-        if (shortBlockName.startsWith(`${b}-`)) {
-          const options = shortBlockName.substring(b.length + 1).split('-').filter((opt) => !!opt);
-          shortBlockName = b;
-          block.classList.add(b);
-          block.classList.add(...options);
-        }
-      });
+    for (let i = 0; i < blocksWithOptions.length; i++) {
+      const b = blocksWithOptions[i];
+      if (shortBlockName.startsWith(`${b}-`)) {
+        const options = shortBlockName.substring(b.length + 1).split('-').filter((opt) => !!opt);
+        shortBlockName = b;
+        block.classList.add(b);
+        block.classList.add(...options);
+        break;
+      } else if (shortBlockName === b) {
+        // case: block with option but no option provided (and potentially substring of another block)
+        break;
+      }
     }
+    console.log('found block', blockName, shortBlockName);
     // end CCX custom block option class handling
     block.setAttribute('data-block-name', shortBlockName);
     block.setAttribute('data-block-status', 'initialized');


### PR DESCRIPTION
Fix [MWPW-116045](https://jira.corp.adobe.com/browse/MWPW-116045)

Adds a schema to the page if 2 blocks get the `schema` option:
- How To Steps Carousel block
- Steps block

Test URLs:
- How To Steps Carousel
  - No schema (default behavior)
    - Before: https://main--express-website--adobe.hlx.page/drafts/alex/schemas/how-to-steps-carousel-noschema
    - After: https://more-schemas--express-website--adobe.hlx.page/drafts/alex/schemas/how-to-steps-carousel-noschema
    - Schema validation: https://validator.schema.org/#url=https%3A%2F%2Fmore-schemas--express-website--adobe.hlx.page%2Fdrafts%2Falex%2Fschemas%2Fhow-to-steps-carousel-noschema
  - Schema (use `schema` block options)
    - Before: https://main--express-website--adobe.hlx.page/drafts/alex/schemas/how-to-steps-carousel-schema
    - After: https://more-schemas--express-website--adobe.hlx.page/drafts/alex/schemas/how-to-steps-carousel-schema
    - Schema validation: https://validator.schema.org/#url=https%3A%2F%2Fmore-schemas--express-website--adobe.hlx.page%2Fdrafts%2Falex%2Fschemas%2Fhow-to-steps-carousel-schema

