### PR TITLE
fix: bleed download card

### DIFF
--- a/express/blocks/download-cards/download-cards.css
+++ b/express/blocks/download-cards/download-cards.css
@@ -228,6 +228,10 @@ main .cards.download-cards.bleed .bleed__c p picture {
 
 main .cards.download-cards.bleed .bleed__c p img {
   display: block;
+  object-position: bottom;
+  height: 100%;
+  width: 100%;
+  object-fit: contain;
 }
 
 main .cards.download-cards .card .button-row {


### PR DESCRIPTION
- bleed `download-card` images of any dimension

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/
- After: https://mwpw-114266--express-website--adobe.hlx.page/express/
