### PR TITLE
[MWPW-116099] Enable multiple rating segments

### DIFF
--- a/express/blocks/ratings/ratings.js
+++ b/express/blocks/ratings/ratings.js
@@ -37,6 +37,7 @@ export default async function decorate($block) {
   let votesText;
   let sheet;
   let sheetCamelCase;
+  let actionSegments;
   let ratingTotal;
   let ratingAverage;
   let showRatingAverage = false;
@@ -100,7 +101,7 @@ export default async function decorate($block) {
   }
 
   function determineActionUsed() {
-    // dev mode: check action-used query parameter
+    // "dev" mode: check action-used query parameter
     const u = new URL(window.location.href);
     const param = u.searchParams.get('action-used');
     if (param) {
@@ -109,8 +110,14 @@ export default async function decorate($block) {
     }
 
     // "production" mode: check for audience
-    const audiences = Context.get('audiences');
-    return (audiences && audiences.includes('enableRatingAction'));
+    const segments = Context.get('segments');
+
+    if (actionSegments && segments) {
+      const parsedActionSegments = actionSegments.replace(/ /g, '').split(',').map(Number);
+      return parsedActionSegments.some((segment) => segments.includes(segment));
+    }
+
+    return false;
   }
 
   function submitRating(rating, comment) {
@@ -477,6 +484,9 @@ export default async function decorate($block) {
     }
     if (response.data[0].Total) {
       ratingTotal = parseFloat(response.data[0].Total);
+    }
+    if (response.data[0].Segments) {
+      actionSegments = response.data[0].Segments;
     }
     if (ratingAverage || ratingTotal) {
       document.dispatchEvent(new Event('ratings_received'));

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -953,9 +953,26 @@ loadScript(martechURL, () => {
   decorateAnalyticsEvents();
 
   const ENABLE_PRICING_MODAL_AUDIENCE = 'enablePricingModal';
-  const ENABLE_RATE_ACTION_AUDIENCE = 'enableRatingAction';
   const RETURNING_VISITOR_SEGMENT_ID = 23153796;
-  const USED_ACTION_SEGMENT_ID = 24241150;
+
+  const QUICK_ACTION_SEGMENTS = [
+    [24241150, 'enableRemoveBackgroundRating'],
+    [24793469, 'enableConvertToGifRating'],
+    [24793470, 'enableConvertToJpgRating'],
+    [24793471, 'enableConvertToMp4Rating'],
+    [24793472, 'enableConvertToPngRating'],
+    [24793473, 'enableConvertToSvgRating'],
+    [24793474, 'enableCropImageRating'],
+    [24793475, 'enableCropVideoRating'],
+    [24793476, 'enableLogoMakerRating'],
+    [24793477, 'enableMergeVideoRating'],
+    [24793478, 'enableQrGeneratorRating'],
+    [24793479, 'enableResizeImageRating'],
+    [24793480, 'enableChangeSpeedRating'],
+    [24793481, 'enableTrimVideoRating'],
+    [24793483, 'enableResizeVideoRating'],
+    [24793488, 'enableReverseVideoRating'],
+  ];
 
   Context.set('audiences', []);
   Context.set('segments', []);
@@ -1014,12 +1031,14 @@ loadScript(martechURL, () => {
             }
           }
 
-          if (json && json.segments && json.segments.includes(USED_ACTION_SEGMENT_ID)) {
-            const audiences = Context.get('audiences');
-            const segments = Context.get('segments');
-            audiences.push(ENABLE_RATE_ACTION_AUDIENCE);
-            segments.push(USED_ACTION_SEGMENT_ID);
-          }
+          QUICK_ACTION_SEGMENTS.forEach((QUICK_ACTION_SEGMENT) => {
+            if (json && json.segments && json.segments.includes(QUICK_ACTION_SEGMENT[0])) {
+              const audiences = Context.get('audiences');
+              const segments = Context.get('segments');
+              audiences.push(QUICK_ACTION_SEGMENT[1]);
+              segments.push(QUICK_ACTION_SEGMENT[0]);
+            }
+          });
 
           document.dispatchEvent(new Event('context_loaded'));
         };


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix [MWPW-116099](https://jira.corp.adobe.com/browse/MWPW-116099)

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/feature/image/remove-background
- After: https://mwpw-116099--express-website--webistry-development.hlx.page/express/feature/image/remove-background

This PR aims to add multiple segments to allow rating on different quick action pages. I suggest that in the future maybe we should migrate the segments array to either a dedicated sheet, or a metadata row.

You can test the different pages by referring to the segments on the JIRA task and adding/removing those segments for yourself.

This is still currently being tested by Abhinav and his team, and should not be merged at the moment.