### PR TITLE
fix: stack free plan widget for long CTAs

### DIFF
--- a/express/blocks/columns/columns.css
+++ b/express/blocks/columns/columns.css
@@ -798,6 +798,10 @@ main .columns.highlight .column.column-picture {
   }
 }
 
+main .columns.center .button-container.free-plan-container.stacked .free-plan-widget {
+  padding-left: 24px;
+}
+
 @media (max-width: 600px) {
   :lang(ja) main .columns h2 {
     font-size: var(--heading-font-size-l);

--- a/express/blocks/hero-animation/hero-animation.css
+++ b/express/blocks/hero-animation/hero-animation.css
@@ -301,26 +301,6 @@ main .hero-animation.wide .button-container.free-plan-container .free-plan-widge
   background-color: transparent;
 }
 
-main .hero-animation .button-container.free-plan-container.stacked {
-  margin-top: 0;
-}
-
-main .hero-animation .button-container.free-plan-container.stacked .free-plan-widget {
-  padding-left: 0;
-}
-
-main .hero-animation .button-container.free-plan-container.stacked {
-  flex-wrap: wrap;
-}
-
-main .hero-animation .button-container.free-plan-container.stacked .free-plan-widget {
-  flex-direction: row;
-}
-
-main .hero-animation .button-container.free-plan-container.stacked .free-plan-widget > div {
-  margin-right: 16px;
-}
-
 /* Japanese font sizing styles */
 
 :lang(ja) main .hero-animation h1 {

--- a/express/blocks/hero-animation/hero-animation.js
+++ b/express/blocks/hero-animation/hero-animation.js
@@ -231,12 +231,6 @@ export default async function decorate($block) {
         transformToVideoLink($div, videoLink);
       }
       addFreePlanWidget($div.querySelector('.button-container') || $div.children[0]);
-      // stack CTA and free plan widget if CTA text is japanese or exceeds 22 characters
-      const $cta = $div.querySelector('.button.accent');
-      const ctaLength = $cta && $cta.textContent.trim().length;
-      if (ctaLength > 22 || getLocale(window.location) === 'jp') {
-        $cta.parentElement.classList.add('stacked');
-      }
     }
 
     if (rowType === 'option') {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -2128,6 +2128,11 @@ export async function addFreePlanWidget(elem) {
     `;
     elem.append(widget);
     elem.classList.add('free-plan-container');
+    // stack CTA and free plan widget if country not US, CN, KR or TW
+    const cta = elem.querySelector('.button.accent');
+    if (!['us', 'cn', 'kr', 'tw'].includes(getLocale(window.location))) {
+      cta.parentElement.classList.add('stacked');
+    }
   }
 }
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -2130,8 +2130,8 @@ export async function addFreePlanWidget(elem) {
     elem.classList.add('free-plan-container');
     // stack CTA and free plan widget if country not US, CN, KR or TW
     const cta = elem.querySelector('.button.accent');
-    if (!['us', 'cn', 'kr', 'tw'].includes(getLocale(window.location))) {
-      cta.parentElement.classList.add('stacked');
+    if (cta && !['us', 'cn', 'kr', 'tw'].includes(getLocale(window.location))) {
+      elem.classList.add('stacked');
     }
   }
 }

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -896,6 +896,21 @@ main .block .free-plan-widget .icon.icon-checkmark {
   main .block.center .free-plan-widget {
     margin: 0 auto;
   }
+
+  main .block .button-container.free-plan-container.stacked {
+    margin-top: 0;
+    flex-wrap: wrap;
+  }
+
+  main .block .button-container.free-plan-container.stacked .free-plan-widget {
+    padding-left: 0;
+    flex-direction: row;
+    background-color: transparent;
+  }
+
+  main .block .button-container.free-plan-container.stacked .free-plan-widget > div {
+    margin-right: 16px;
+  }
 }
 
 @media (min-width: 1200px) {


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://jira.corp.adobe.com/browse/MWPW-116370

Any other language than English, Chinese, Taiwanese or Korean will get a stacked layout on desktop to leave enough room for the CTA text:

Test URLs:
- German homepage
   - Before: https://main--express-website--adobe.hlx.page/de/express/
   - After: https://mwpw-116370--express-website--adobe.hlx.page/de/express/?lighthouse=on
- German create page
   - Before: https://main--express-website--adobe.hlx.page/de/express/create/logo
   - After: https://mwpw-116370--express-website--adobe.hlx.page/de/express/create/logo?lighthouse=on
- German feature page
   - Before: https://main--express-website--adobe.hlx.page/de/express/feature/image/remove-background
   - After: https://mwpw-116370--express-website--adobe.hlx.page/de/express/feature/image/remove-background?lighthouse=on

Regression check:
   - Before: https://main--express-website--adobe.hlx.page/express/
   - After: https://mwpw-116370--express-website--adobe.hlx.page/express/?lighthouse=on