### PR TITLE
fix(choose-your-path): keep mouse text inside bubble

### DIFF
--- a/express/blocks/choose-your-path/choose-your-path.css
+++ b/express/blocks/choose-your-path/choose-your-path.css
@@ -82,6 +82,11 @@ main .choose-your-path .choose-your-path-slide .choose-your-path-slide-image img
     height: 160px;
 }
 
+main .choose-your-path .choose-your-path-mouse-container {
+    max-width: 156px;
+    max-height: 100px;
+}
+
 @media (min-width: 600px) {
     main .choose-your-path {
         flex-direction: row;


### PR DESCRIPTION
The text on the mouse "bubble" can run out of bounds:
![image](https://user-images.githubusercontent.com/1609742/188559357-eabed558-c124-4c40-ad65-e1215e234ae5.png)

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/fr/express/paths
- After: https://path-mouse-text--express-website--adobe.hlx.page/fr/express/paths?lighthouse=on
