### PR TITLE
How to steps restyle

### DIFF
--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -32,12 +32,19 @@ main .how-to-steps > div {
 }
 
 main .how-to-steps .tip {
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: flex-start;
+  display: grid;
+}
+
+main .how-to-steps .tip-number{
+  grid-area: 1/1/1/1;
+}
+
+main .how-to-steps .tip-heading {
+  grid-area: 1/2/1/2;                               
+}
+
+main .how-to-steps .tip-text {
+  grid-area: 2/2/2/2;
 }
 
 main .how-to-steps .tip-text p {
@@ -46,10 +53,17 @@ main .how-to-steps .tip-text p {
   margin-bottom: 0;
 }
 
-main .how-to-steps .tip-text h3 {
-  margin-bottom: 16px;
+
+
+main .how-to-steps .tip-heading h3 {
+  height: 100%;
+  display: flex;
+  justify-content: flex-start;
   font-size: var(--heading-font-size-s);
   text-align: left;
+  align-content: center;
+  align-items: center;
+  margin-top:0;
 }
 
 main .how-to-steps .tip-number {
@@ -86,8 +100,15 @@ main .how-to-steps .tip-number span {
     min-height: 70px;
     margin-right: 24px;
   }
-  main .how-to-steps .tip-text h3 {
+  main .how-to-steps .tip-heading h3 {
+    height: 100%;
+    display: flex;
+    justify-content: flex-start;
     font-size: var(--heading-font-size-m);
+    text-align: left;
+    align-content: center;
+    align-items: center;
+    margin-top: 0;
   }
   main .how-to-steps .tip-text p {
     font-size: var(--body-font-size-xl);

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -47,8 +47,8 @@ export default function decorate($block, name, doc) {
     const $p = createTag('p');
     $p.innerHTML = $cells[1].innerHTML;
     const $heading = createTag('div', { class: 'tip-heading' });
-    $text.append($h3);
-    const $text = createTag('div', { class: 'tip-text'});
+    $heading.append($h3);
+    const $text = createTag('div', { class: 'tip-text' });
     $text.append($p);
     const $number = createTag('div', { class: 'tip-number' });
     $number.innerHTML = `<span>${i + 1}</span>`;
@@ -56,7 +56,7 @@ export default function decorate($block, name, doc) {
     $cells[1].innerHTML = '';
     $cells[1].classList.add('tip');
     $cells[1].append($number);
-    $cells[1].append($heading)
+    $cells[1].append($heading);
     $cells[1].append($text);
   });
 

--- a/express/blocks/how-to-steps/how-to-steps.js
+++ b/express/blocks/how-to-steps/how-to-steps.js
@@ -46,8 +46,9 @@ export default function decorate($block, name, doc) {
     $h3.innerHTML = $cells[0].textContent;
     const $p = createTag('p');
     $p.innerHTML = $cells[1].innerHTML;
-    const $text = createTag('div', { class: 'tip-text' });
+    const $heading = createTag('div', { class: 'tip-heading' });
     $text.append($h3);
+    const $text = createTag('div', { class: 'tip-text'});
     $text.append($p);
     const $number = createTag('div', { class: 'tip-number' });
     $number.innerHTML = `<span>${i + 1}</span>`;
@@ -55,6 +56,7 @@ export default function decorate($block, name, doc) {
     $cells[1].innerHTML = '';
     $cells[1].classList.add('tip');
     $cells[1].append($number);
+    $cells[1].append($heading)
     $cells[1].append($text);
   });
 


### PR DESCRIPTION
The current how-to-steps bullet point has some styling that looks off. I was asked to fix it; make things align better, primarily the bullet point number and the heading! 

I was given the following guideline!


![image](https://user-images.githubusercontent.com/12217245/188951364-f0df26a0-54ac-442b-bd8c-94e28c329746.png)

Fix <jira-issue-id>

Test URLs:
BLOG:

  - Before: https://main--express-website--adobe.hlx.page/express/learn/blog/cool-pfp-for-instagram
  - After: https://how-to-steps-restyle--express-website--adobe.hlx.page/express/learn/blog/cool-pfp-for-instagram
  
MAIN:
  - Before: https://main--express-website--adobe.hlx.page/express/create/video/intro/wedding
  - After: https://fix-how-to-step--express-website--adobe.hlx.page/express/create/video/intro/wedding
  - Before: https://main--express-website--adobe.hlx.page/express/create/logo/fortnite
  - After: https://fix-how-to-step--express-website--adobe.hlx.page/express/create/logo/fortnite
  - Before: https://main--express-website--adobe.hlx.page/express/feature/design/add-icons
  - After: https://fix-how-to-step--express-website--adobe.hlx.page/express/feature/design/add-icons
  - Before: https://main--express-website--adobe.hlx.page/express/discover/ideas/halloween-party
  - After: https://fix-how-to-step--express-website--adobe.hlx.page/express/discover/ideas/halloween-party



