### PR TITLE
fix: change width unit

### DIFF
--- a/express/blocks/hero-3d/hero-3d.css
+++ b/express/blocks/hero-3d/hero-3d.css
@@ -87,7 +87,7 @@ main .hero-3d iframe {
     border-width: 0px;
     border: none;
     z-index: 0;
-    width: 100vw;
+    width: 100%;
     pointer-events: all;
     padding-top: var(--header-height);
 }


### PR DESCRIPTION
- use % instead of vw to fix scrollbar issue on windows browsers

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/design-app
- After: https://mwpw-114266--express-website--adobe.hlx.page/express/design-app
