### PR TITLE
fix(blocks/how-to-steps/how-to-steps.css): tmp fix

### DIFF
--- a/express/blocks/how-to-steps/how-to-steps.css
+++ b/express/blocks/how-to-steps/how-to-steps.css
@@ -47,6 +47,7 @@ main .how-to-steps .tip-text p {
 }
 
 main .how-to-steps .tip-text h3 {
+  margin-top: 0px;
   margin-bottom: 16px;
   font-size: var(--heading-font-size-s);
   text-align: left;


### PR DESCRIPTION
override margin on top of h3

blog posts have additional margin that interfere with block styling! 


BLOG Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/learn/blog/cool-pfp-for-instagram
- After: https://fix-how-to-step--express-website--adobe.hlx.page/express/learn/blog/cool-pfp-for-instagram

MAIN Test URLs:
MAIN:

Before: https://main--express-website--adobe.hlx.page/express/create/video/intro/wedding
After: https://fix-how-to-step--express-website--adobe.hlx.page/express/create/video/intro/wedding

Before: https://main--express-website--adobe.hlx.page/express/create/logo/fortnite
After: https://fix-how-to-step--express-website--adobe.hlx.page/express/create/logo/fortnite

Before: https://main--express-website--adobe.hlx.page/express/feature/design/add-icons
After: https://fix-how-to-step--express-website--adobe.hlx.page/express/feature/design/add-icons

Before: https://main--express-website--adobe.hlx.page/express/discover/ideas/halloween-party
After: https://fix-how-to-step--express-website--adobe.hlx.page/express/discover/ideas/halloween-party

