### PR TITLE
fix(floating-button): fix the bug with floating-button when there is an empty section above the hero

### DIFF
--- a/express/blocks/floating-button/floating-button.js
+++ b/express/blocks/floating-button/floating-button.js
@@ -118,7 +118,7 @@ export async function createFloatingButton($a) {
     }
   }
 
-  const $heroCTA = document.querySelector('a.button.same-as-floating-buttton-CTA');
+  const $heroCTA = document.querySelector('a.button.same-as-floating-button-CTA');
   if ($heroCTA) {
     const hideButtonWhenIntersecting = new IntersectionObserver((entries) => {
       const $e = entries[0];

--- a/express/blocks/floating-button/floating-button.js
+++ b/express/blocks/floating-button/floating-button.js
@@ -118,7 +118,7 @@ export async function createFloatingButton($a) {
     }
   }
 
-  const $heroCTA = document.querySelector('a.button.xlarge.same-as-floating-buttton-CTA');
+  const $heroCTA = document.querySelector('a.button.same-as-floating-buttton-CTA');
   if ($heroCTA) {
     const hideButtonWhenIntersecting = new IntersectionObserver((entries) => {
       const $e = entries[0];

--- a/express/blocks/floating-button/floating-button.js
+++ b/express/blocks/floating-button/floating-button.js
@@ -118,8 +118,7 @@ export async function createFloatingButton($a) {
     }
   }
 
-  const $hero = document.querySelector('div.section');
-  const $heroCTA = $hero.querySelector('a.button.same-as-floating-button-CTA');
+  const $heroCTA = document.querySelector('a.button.xlarge.same-as-floating-buttton-CTA');
   if ($heroCTA) {
     const hideButtonWhenIntersecting = new IntersectionObserver((entries) => {
       const $e = entries[0];


### PR DESCRIPTION
When there is a buggy 'empty section' above the hero, the floating button wasn't working correctly. 

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/
- After: https://main--express-website--webistry-development.hlx.page/express/
.
- Before: https://main--express-website--adobe.hlx.page/express/learn/express-your-brand
- After: https://main--express-website--webistry-development.hlx.page/express/learn/express-your-brand
.
- Before: https://main--express-website--adobe.hlx.page/express/create/flyer
- After: https://main--express-website--webistry-development.hlx.page/express/create/flyer
.
buggy page:
- Before: https://main--express-website--adobe.hlx.live/express/create/flyer
- After: https://main--express-website--webistry-development.hlx.live/express/create/flyer