### PR TITLE
fix(floating-button): move to the bottom of main instead of the top

### DIFF
--- a/express/blocks/floating-button/floating-button.js
+++ b/express/blocks/floating-button/floating-button.js
@@ -41,10 +41,10 @@ export async function createFloatingButton($a) {
   });
   const linksPopulated = new CustomEvent('linkspopulated', { detail: [$floatButtonLink, $lottieScrollButton] });
   document.dispatchEvent(linksPopulated);
-  $floatButton.appendChild($floatButtonLink);
-  $floatButton.appendChild($lottieScrollButton);
-  $floatButtonWrapper.appendChild($floatButton);
-  main.prepend($floatButtonWrapper);
+  $floatButton.append($floatButtonLink);
+  $floatButton.append($lottieScrollButton);
+  $floatButtonWrapper.append($floatButton);
+  main.append($floatButtonWrapper);
   if ($floatButtonWrapperOld) {
     const $parent = $floatButtonWrapperOld.parentElement;
     if ($parent && $parent.children.length === 1) {


### PR DESCRIPTION
Fix any potential bugs with the sections due to the floating wrapper being at the top of `main` by moving the floating button to the bottom instead.

Test URLs:

Before: https://main--express-website--adobe.hlx.page/express/
After: https://main--express-website--webistry-development.hlx.page/express/
.
Before: https://main--express-website--adobe.hlx.page/express/learn/express-your-brand
After: https://main--express-website--webistry-development.hlx.page/express/learn/express-your-brand
.
Before: https://main--express-website--adobe.hlx.page/express/create/flyer
After: https://main--express-website--webistry-development.hlx.page/express/create/flyer