### PR TITLE
[MWPW-117208] Fix quick action split issues

### DIFF
--- a/express/blocks/split-action/split-action.css
+++ b/express/blocks/split-action/split-action.css
@@ -1,3 +1,8 @@
+main .split-action-container {
+    display: none;
+    opacity: 0;
+}
+
 main .split-action {
     position: fixed;
     bottom: 0;
@@ -7,7 +12,7 @@ main .split-action {
     margin: 10px;
     padding: 24px;
     border-radius: 24px;
-    z-index: 99;
+    z-index: 110;
     background: linear-gradient(320deg, #7C84F3, #FF4DD2, #FF993B, #FF4DD2, #7C84F3, #FF4DD2, #FF993B);
     background-size: 400% 400%;
     -webkit-animation: buttonGradient 45s ease infinite;

--- a/express/blocks/split-action/split-action.css
+++ b/express/blocks/split-action/split-action.css
@@ -12,7 +12,7 @@ main .split-action {
     margin: 10px;
     padding: 24px;
     border-radius: 24px;
-    z-index: 110;
+    z-index: 100001;
     background: linear-gradient(320deg, #7C84F3, #FF4DD2, #FF993B, #FF4DD2, #7C84F3, #FF4DD2, #FF993B);
     background-size: 400% 400%;
     -webkit-animation: buttonGradient 45s ease infinite;
@@ -28,7 +28,7 @@ main .block-background {
     height: 100%;
     width: 100%;
     background-color: var(--color-white);
-    z-index: 90;
+    z-index: 100000;
 }
 
 main .block-background .underlay {

--- a/express/blocks/split-action/split-action.js
+++ b/express/blocks/split-action/split-action.js
@@ -12,19 +12,6 @@
 
 import { createTag, getIconElement } from '../../scripts/scripts.js';
 
-function hide($block) {
-  const body = document.querySelector('body');
-  body.style.overflow = 'auto';
-  const $blockWrapper = $block.parentNode;
-  if ($blockWrapper.parentElement.classList.contains('split-action-container')) {
-    $blockWrapper.parentElement.style.opacity = '0';
-    $block.style.bottom = `-${$block.offsetHeight}px`;
-    setTimeout(() => {
-      $blockWrapper.parentElement.style.display = 'none';
-    }, 200);
-  }
-}
-
 function show($block) {
   const body = document.querySelector('body');
   body.style.overflow = 'hidden';
@@ -88,6 +75,7 @@ export default function decorate($block) {
 
   Array.from($block.children).forEach((div) => {
     const anchor = div.querySelector('a');
+
     if (anchor) {
       $buttonsWrapper.append(anchor);
       div.remove();
@@ -112,11 +100,10 @@ export default function decorate($block) {
 
   [$notch, $underlay].forEach((element) => {
     element.addEventListener('click', () => {
-      hide($block);
+      const $actionCta = $block.querySelector('.same-as-floating-button-CTA');
+      window.location.href = $actionCta.href;
     });
   });
-
-  hide($block);
 
   if (window.innerWidth < 900) {
     initNotchDragAction($block);


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://jira.corp.adobe.com/browse/MWPW-117208

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/feature/image/remove-background
- After: https://mwpw-117208--express-website--webistry-development.hlx.page/express/feature/image/remove-background

- Sliding down the quick action menu now redirects to the action.
- Clicking on the "stay on web" call to action now redirects to the action.
- Clicking on the background image behind the quick action split now redirects to the action.
- Adjusted the z-index in order to hide the promotional banner when necessary.

Unfortunately, the promotional banner doesn't seem to show on branch environments, so the last fix will have to be tested in the main environment.