### PR TITLE
fix(hero-3d): append download icon to all except italic CTAs

### DIFF
--- a/express/blocks/hero-3d/hero-3d.js
+++ b/express/blocks/hero-3d/hero-3d.js
@@ -64,10 +64,9 @@ function loadSplineFrame(block, href, delay = 0) {
  * @param {HTMLDivElement} block
  */
 export function prependDownloadIcon(block) {
-  const ctas = block.querySelectorAll('.button-container a');
-
+  const ctas = block.querySelectorAll('.button-container a.button');
   ctas.forEach((cta) => {
-    if (cta.innerText.toLowerCase().startsWith('download')) {
+    if (cta.parentElement.tagName !== 'EM') {
       const icon = getIconElement('download');
       cta.prepend(icon);
     }


### PR DESCRIPTION
Currently download icons are added based on button text, which doesn't work well for i18n. I propose to always add a download icon to a button on a download card, unless its parent is an `<em>` (italic in Word).

(This PR also removes the invisible download icon from the Microsoft store badge, keeping it more centered.)

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/de/express/design-app
- After: https://download-card-i18n-fix--express-website--adobe.hlx.page/de/express/design-app
