### PR TITLE
[MWPW-117101] - Fixing the scroll interaction on floating-button block

### DIFF
--- a/express/blocks/floating-button/floating-button.js
+++ b/express/blocks/floating-button/floating-button.js
@@ -55,7 +55,7 @@ export async function createFloatingButton($a) {
   }
 
   // Floating button scroll/click events
-  const $scrollAnchor = document.querySelector('.block.template-list, .block.layouts, .steps-highlight-container') ?? document.querySelector('.section:nth-of-type(3)');
+  const $scrollAnchor = document.querySelector('.section:not(:nth-child(1)):not(:nth-child(2)) .template-list, .section:not(:nth-child(1)):not(:nth-child(2)) .layouts, .section:not(:nth-child(1)):not(:nth-child(2)) .steps-highlight-container') ?? document.querySelector('.section:nth-child(3)');
   const hideScrollArrow = () => {
     $floatButtonWrapper.classList.add('floating-button--scrolled');
     if (document.activeElement === $lottieScrollButton) $lottieScrollButton.blur();


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://jira.corp.adobe.com/browse/MWPW-117101

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/create/flyer
- After: https://mwpw-117101--express-website--webistry-development.hlx.page/express/create/flyer

The scroll down button on the floating-button block has been adjusted. It would be worth while testing on all of the following urls as well:

https://main--express-website--adobe.hlx.page/express/
https://main--express-website--adobe.hlx.page/express/learn/express-your-brand
https://main--express-website--adobe.hlx.page/express/learn/students
https://main--express-website--adobe.hlx.page/education/express/classroom-accounts
https://main--express-website--adobe.hlx.page/express/nonprofits
https://main--express-website--adobe.hlx.page/education/express/for-teachers

https://mwpw-117101--express-website--webistry-development.hlx.page/express
https://mwpw-117101--express-website--webistry-development.hlx.page/express/learn/express-your-brand
https://mwpw-117101--express-website--webistry-development.hlx.page/express/learn/students
https://mwpw-117101--express-website--webistry-development.hlx.page/education/express/classroom-accounts
https://mwpw-117101--express-website--webistry-development.hlx.page/express/nonprofits
https://mwpw-117101--express-website--webistry-development.hlx.page/education/express/for-teachers

On the ones tested, this worked as intended for me.
