### PR TITLE
refactor(rum): align rum code with recent boilerplate changes this is needed to allow dynamic dropping of sampling rate based on presence of experiments

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -13,7 +13,7 @@
 
 window.RUM_GENERATION = 'ccx-gen-4-experiment-high-sample-rate';
 window.RUM_LOW_SAMPLE_RATE = 100;
-window.RUM_HIGH_SAMPLE_RATE = 10;
+window.RUM_HIGH_SAMPLE_RATE = 50;
 
 /**
  * log RUM if part of the sample.

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -11,7 +11,7 @@
  */
 /* eslint-disable no-console */
 
-window.RUM_GENERATION = 'ccx-gen-3';
+window.RUM_GENERATION = 'ccx-gen-4-boilerplate';
 
 /**
  * log RUM if part of the sample.
@@ -20,6 +20,23 @@ window.RUM_GENERATION = 'ccx-gen-3';
  */
 
 export function sampleRUM(checkpoint, data = {}) {
+  sampleRUM.defer = sampleRUM.defer || [];
+  const defer = (fnname) => {
+    sampleRUM[fnname] = sampleRUM[fnname]
+      || ((...args) => sampleRUM.defer.push({ fnname, args }));
+  };
+  sampleRUM.drain = sampleRUM.drain
+    || ((dfnname, fn) => {
+      sampleRUM[dfnname] = fn;
+      sampleRUM.defer
+        .filter(({ fnname }) => dfnname === fnname)
+        .forEach(({ fnname, args }) => sampleRUM[fnname](...args));
+    });
+  sampleRUM.on = (chkpnt, fn) => {
+    sampleRUM.cases[chkpnt] = fn;
+  };
+  defer('observe');
+  defer('cwv');
   try {
     window.hlx = window.hlx || {};
     if (!window.hlx.rum) {
@@ -31,99 +48,39 @@ export function sampleRUM(checkpoint, data = {}) {
       const random = Math.random();
       const isSelected = (random * weight < 1);
       // eslint-disable-next-line object-curly-newline
-      window.hlx.rum = { weight, id, random, isSelected };
+      window.hlx.rum = { weight, id, random, isSelected, sampleRUM };
     }
-    const { random, weight, id } = window.hlx.rum;
-    if (random && (random * weight < 1)) {
-      const sendPing = () => {
+    const { weight, id } = window.hlx.rum;
+    if (window.hlx && window.hlx.rum && window.hlx.rum.isSelected) {
+      const sendPing = (pdata = data) => {
         // eslint-disable-next-line object-curly-newline, max-len, no-use-before-define
         const body = JSON.stringify({ weight, id, referer: window.location.href, generation: window.RUM_GENERATION, checkpoint, ...data });
         const url = `https://rum.hlx.page/.rum/${weight}`;
         // eslint-disable-next-line no-unused-expressions
         navigator.sendBeacon(url, body);
+        // eslint-disable-next-line no-console
+        console.debug(`ping:${checkpoint}`, pdata);
       };
-      sendPing();
-      // special case CWV
-      if (checkpoint === 'cwv') {
-        // use classic script to avoid CORS issues
-        const script = document.createElement('script');
-        script.src = 'https://rum.hlx.page/.rum/web-vitals/dist/web-vitals.iife.js';
-        script.onload = () => {
-          const storeCWV = (measurement) => {
-            data.cwv = {};
-            data.cwv[measurement.name] = measurement.value;
-            sendPing();
-          };
-          // When loading `web-vitals` using a classic script, all the public
-          // methods can be found on the `webVitals` global namespace.
-          window.webVitals.getCLS(storeCWV);
-          window.webVitals.getFID(storeCWV);
-          window.webVitals.getLCP(storeCWV);
-        };
-        document.head.appendChild(script);
+      sampleRUM.cases = sampleRUM.cases || {
+        cwv: () => sampleRUM.cwv(data) || true,
+        lazy: () => {
+          // use classic script to avoid CORS issues
+          const script = document.createElement('script');
+          script.src = 'https://rum.hlx.page/.rum/@adobe/helix-rum-enhancer@^1/src/index.js';
+          document.head.appendChild(script);
+          sendPing(data);
+          return true;
+        },
+      };
+      sendPing(data);
+      if (sampleRUM.cases[checkpoint]) {
+        sampleRUM.cases[checkpoint]();
       }
     }
-  } catch (e) {
+  } catch (error) {
     // something went wrong
   }
 }
-
-sampleRUM.mediaobserver = (window.IntersectionObserver) ? new IntersectionObserver((entries) => {
-  entries
-    .filter((entry) => entry.isIntersecting)
-    .forEach((entry) => {
-      sampleRUM.mediaobserver.unobserve(entry.target); // observe only once
-      const target = sampleRUM.targetselector(entry.target);
-      const source = sampleRUM.sourceselector(entry.target);
-      sampleRUM('viewmedia', { target, source });
-    });
-}, { threshold: 0.25 }) : { observe: () => { } };
-
-sampleRUM.blockobserver = (window.IntersectionObserver) ? new IntersectionObserver((entries) => {
-  entries
-    .filter((entry) => entry.isIntersecting)
-    .forEach((entry) => {
-      sampleRUM.blockobserver.unobserve(entry.target); // observe only once
-      const target = sampleRUM.targetselector(entry.target);
-      const source = sampleRUM.sourceselector(entry.target);
-      sampleRUM('viewblock', { target, source });
-    });
-}, { threshold: 0.25 }) : { observe: () => { } };
-
-sampleRUM.observe = ((elements) => {
-  elements.forEach((element) => {
-    if (element.tagName.toLowerCase() === 'img'
-      || element.tagName.toLowerCase() === 'video'
-      || element.tagName.toLowerCase() === 'audio'
-      || element.tagName.toLowerCase() === 'iframe') {
-      sampleRUM.mediaobserver.observe(element);
-    } else {
-      sampleRUM.blockobserver.observe(element);
-    }
-  });
-});
-
-sampleRUM.sourceselector = (element) => {
-  if (element === document.body || element === document.documentElement || !element) {
-    return undefined;
-  }
-  if (element.id) {
-    return `#${element.id}`;
-  }
-  if (element.getAttribute('data-block-name')) {
-    return `.${element.getAttribute('data-block-name')}`;
-  }
-  return sampleRUM.sourceselector(element.parentElement);
-};
-
-sampleRUM.targetselector = (element) => {
-  let value = element.getAttribute('href') || element.currentSrc || element.getAttribute('src');
-  if (value && value.startsWith('https://')) {
-    // resolve relative links
-    value = new URL(value, window.location).href;
-  }
-  return value;
-};
 
 sampleRUM('top');
 window.addEventListener('load', () => sampleRUM('load'));
@@ -2168,6 +2125,7 @@ async function loadLazy() {
   addFavIcon('/express/icons/cc-express.svg');
   if (!window.hlx.lighthouse) loadMartech();
 
+  sampleRUM('lazy');
   sampleRUM.observe(document.querySelectorAll('main picture > img'));
   sampleRUM.observe(main.querySelectorAll('div[data-block-name]'));
 }

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -11,7 +11,9 @@
  */
 /* eslint-disable no-console */
 
-window.RUM_GENERATION = 'ccx-gen-4-boilerplate';
+window.RUM_GENERATION = 'ccx-gen-4-experiment-high-sample-rate';
+window.RUM_LOW_SAMPLE_RATE = 100;
+window.RUM_HIGH_SAMPLE_RATE = 10;
 
 /**
  * log RUM if part of the sample.
@@ -37,11 +39,12 @@ export function sampleRUM(checkpoint, data = {}) {
   };
   defer('observe');
   defer('cwv');
+  defer('stash');
   try {
     window.hlx = window.hlx || {};
     if (!window.hlx.rum) {
       const usp = new URLSearchParams(window.location.search);
-      const weight = (usp.get('rum') === 'on') ? 1 : 100; // with parameter, weight is 1. Defaults to 100.
+      const weight = (usp.get('rum') === 'on') ? 1 : window.RUM_LOW_SAMPLE_RATE;
       // eslint-disable-next-line no-bitwise
       const hashCode = (s) => s.split('').reduce((a, b) => (((a << 5) - a) + b.charCodeAt(0)) | 0, 0);
       const id = `${hashCode(window.location.href)}-${new Date().getTime()}-${Math.random().toString(16).substr(2, 14)}`;
@@ -50,16 +53,19 @@ export function sampleRUM(checkpoint, data = {}) {
       // eslint-disable-next-line object-curly-newline
       window.hlx.rum = { weight, id, random, isSelected, sampleRUM };
     }
-    const { weight, id } = window.hlx.rum;
-    if (window.hlx && window.hlx.rum && window.hlx.rum.isSelected) {
+    const { id } = window.hlx.rum;
+    if ((window.hlx && window.hlx.rum && window.hlx.rum.isSelected) || checkpoint === 'experiment') {
       const sendPing = (pdata = data) => {
+        if (!window.hlx.rum.isSelected) {
+          return;
+        }
         // eslint-disable-next-line object-curly-newline, max-len, no-use-before-define
-        const body = JSON.stringify({ weight, id, referer: window.location.href, generation: window.RUM_GENERATION, checkpoint, ...data });
-        const url = `https://rum.hlx.page/.rum/${weight}`;
+        const body = JSON.stringify({ weight: window.hlx.rum.weight, id, referer: window.location.href, generation: window.RUM_GENERATION, checkpoint, ...data });
+        const url = `https://rum.hlx.page/.rum/${window.hlx.rum.weight}`;
         // eslint-disable-next-line no-unused-expressions
         navigator.sendBeacon(url, body);
         // eslint-disable-next-line no-console
-        console.debug(`ping:${checkpoint}`, pdata);
+        console.debug(`ping:${checkpoint}:${window.hlx.rum.weight}`, pdata);
       };
       sampleRUM.cases = sampleRUM.cases || {
         cwv: () => sampleRUM.cwv(data) || true,
@@ -71,11 +77,22 @@ export function sampleRUM(checkpoint, data = {}) {
           sendPing(data);
           return true;
         },
+        experiment: () => {
+          // track experiments with higher sampling rate
+          window.hlx.rum.weight = Math.min(window.hlx.rum.weight, window.RUM_HIGH_SAMPLE_RATE);
+          window.hlx.rum.isSelected = (window.hlx.rum.random * window.hlx.rum.weight < 1);
+
+          sampleRUM.drain('stash', sampleRUM);
+          sendPing(data);
+          return true;
+        },
       };
       sendPing(data);
       if (sampleRUM.cases[checkpoint]) {
         sampleRUM.cases[checkpoint]();
       }
+    } else {
+      sampleRUM.stash(checkpoint, data); // save the event for later
     }
   } catch (error) {
     // something went wrong


### PR DESCRIPTION
URL for testing:

1. https://inc-exp-sample-rate--express-website--adobe.hlx.page/express/spotlight/explore
2. https://inc-exp-sample-rate--express-website--adobe.hlx.page/express/spotlight/explore?rum=on
3. https://inc-exp-sample-rate--express-website--adobe.hlx.page/express/spotlight/explore
You should see RUM data being sent (and `console.debug`logged) at every 10th request for the 1st URL, for every request at the second URL, and for every 100th request at the third URL.

There are two big changes here:

- https://github.com/adobe/express-website/pull/603/commits/3040309e3dcf2dc839d8eebe5c8983873ccf0b0c aligns this project with the latest boilerplate code, no surprises here
- https://github.com/adobe/express-website/pull/603/commits/4e2b9c616fd917222d2e6ce9df00f569a7cb7142 uses the `defer` technique introduced in the boilerplate code to `stash` all non-tracked RUM events. When an `experiment` event is seen, the sampling rate will be increased to `RUM_HIGH_SAMPLE_RATE = 10` and all stashed events will be `drain`ed (e.g. replayed, with a much higher chance of being sampled).

I've decided against introducing a timestamp system for these recorded events, as this would mean additional complexity that isn't reflected in the reporting at all. The only observable effect will be that pages with experiments will have a full milliseconds shorter observed dwell time, which isn't used in any reports except the exceptional experience score calculation.