### PR TITLE
chore: map non-english templates folders

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -5,3 +5,17 @@ mountpoints:
 folders:
   /express/templates/content.json: /metadata.json
   /express/templates/: /express/templates/default
+  /br/express/templates/: /express/templates/default
+  /cn/express/templates/: /express/templates/default
+  /de/express/templates/: /express/templates/default
+  /dk/express/templates/: /express/templates/default
+  /es/express/templates/: /express/templates/default
+  /fi/express/templates/: /express/templates/default
+  /fr/express/templates/: /express/templates/default
+  /it/express/templates/: /express/templates/default
+  /jp/express/templates/: /express/templates/default
+  /kr/express/templates/: /express/templates/default
+  /nl/express/templates/: /express/templates/default
+  /no/express/templates/: /express/templates/default
+  /se/express/templates/: /express/templates/default
+  /tw/express/templates/: /express/templates/default


### PR DESCRIPTION
Allow mapping of international URLs.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/jp/express/templates/flyer/christmas
- After: https://map-lang-folders--express-website--adobe.hlx.page/jp/express/templates/flyer/christmas?lighthouse=on
