### PR TITLE
fix: temporarily disable smooth scrolling

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -2134,6 +2134,16 @@ export async function addFreePlanWidget(elem) {
       $learnMoreButton.append(lottieWrapper);
       lazyLoadLottiePlayer();
       widget.append($learnMoreButton);
+
+      $learnMoreButton.addEventListener('click', (e) => {
+        e.preventDefault();
+        // temporarily disabling smooth scroll for accurate location
+        const $html = document.querySelector('html');
+        $html.style.scrollBehavior = 'unset';
+        const $plansComparison = document.querySelector('.plans-comparison-container');
+        $plansComparison.scrollIntoView();
+        $html.style.removeProperty('scroll-behavior');
+      });
     });
     elem.append(widget);
     elem.classList.add('free-plan-container');


### PR DESCRIPTION
Disabling smooth scroll for a fraction of second for plans comparison learn more button to better locate the blade.

Fix plans comparison blade

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/feature/image/remove-background
- After: https://plans-comparison-scroll-fix--express-website--webistry-development.hlx.page/express/feature/image/remove-background?lighthouse=on
