### PR TITLE
fix: remove smooth scrolling for better locating

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -2134,6 +2134,16 @@ export async function addFreePlanWidget(elem) {
       $learnMoreButton.append(lottieWrapper);
       lazyLoadLottiePlayer();
       widget.append($learnMoreButton);
+
+      $learnMoreButton.addEventListener('click', (e) => {
+        e.preventDefault();
+        // temporarily disabling smooth scroll for accurate location
+        const $html = document.querySelector('html');
+        $html.style.scrollBehavior = 'unset';
+        const $plansComparison = document.querySelector('.plans-comparison-container');
+        $plansComparison.scrollIntoView();
+        $html.style.removeProperty('scroll-behavior');
+      });
     });
     elem.append(widget);
     elem.classList.add('free-plan-container');


### PR DESCRIPTION
The plans comparison learn more button suffers from lazy-loading images shifting content while scrolling, therefore making the final destination of the scrolling incorrect. Removing smooth scrolling for just this feature to prevent that from happening.

Fix plans comparison

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/feature/image/remove-background
- After: https://learn-more-fix--express-website--webistry-development.hlx.page/drafts/qiyundai/create/social-media-graphic
