### PR TITLE
feat: improve SEO and accessibility scores

### DIFF
--- a/express/blocks/category-list/category-list.css
+++ b/express/blocks/category-list/category-list.css
@@ -11,7 +11,7 @@ main .category-list-container .category-list-center-container .carousel-platform
   padding-top: 6px;
 }
 
-main .category-list-container .carousel-container a.button.carousel-arrow {
+main .category-list-container .carousel-container span.button.carousel-arrow {
   transform: translateY(-10px);
 }
 

--- a/express/blocks/category-list/category-list.css
+++ b/express/blocks/category-list/category-list.css
@@ -11,7 +11,7 @@ main .category-list-container .category-list-center-container .carousel-platform
   padding-top: 6px;
 }
 
-main .category-list-container .carousel-container span.button.carousel-arrow {
+main .category-list-container .carousel-container a.button.carousel-arrow {
   transform: translateY(-10px);
 }
 

--- a/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
+++ b/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
@@ -136,7 +136,7 @@ export default function decorate(block) {
     step: [],
   };
 
-  const numbers = createTag('div', { class: 'tip-numbers', 'aria-role': 'tablist' });
+  const numbers = createTag('div', { class: 'tip-numbers', role: 'tablist' });
   block.prepend(numbers);
   const tips = createTag('div', { class: 'tips' });
   block.append(tips);
@@ -173,7 +173,7 @@ export default function decorate(block) {
       class: `tip-number tip-${i + 1}`,
       tabindex: '0',
       title: `${i + 1}`,
-      'aria-role': 'tab',
+      role: 'tab',
     });
     number.innerHTML = `<span>${i + 1}</span>`;
     number.setAttribute('data-tip-index', i + 1);

--- a/express/blocks/plans-comparison/plans-comparison.js
+++ b/express/blocks/plans-comparison/plans-comparison.js
@@ -236,7 +236,7 @@ function decorateFeatures($block, payload, value) {
 }
 
 function decorateCTAs($block, payload, value) {
-  const $buttonsWrapper = createTag('ul', { class: 'ctas-wrapper' });
+  const $buttonsWrapper = createTag('div', { class: 'ctas-wrapper' });
   value.ctas.forEach((cta, index) => {
     $buttonsWrapper.append(cta);
     if (index === 0) {

--- a/express/blocks/playlist/playlist.css
+++ b/express/blocks/playlist/playlist.css
@@ -254,7 +254,7 @@ main .playlist-container .carousel-container .carousel-platform {
     align-items: flex-start;
 }
 
-main .playlist-container .carousel-container a.button.carousel-arrow {
+main .playlist-container .carousel-container span.button.carousel-arrow {
     position: absolute;
     top: 25%;
 }
@@ -316,7 +316,7 @@ main .playlist-container .carousel-container a.button.carousel-arrow {
     main .playlist-container .video-player-video-list-wrapper .video-player-video-list .video-button {
         width: 304px;
     }
-    main .playlist-container .carousel-container a.button.carousel-arrow {
+    main .playlist-container .carousel-container span.button.carousel-arrow {
         position: unset;
         top: unset;
     }

--- a/express/blocks/playlist/playlist.css
+++ b/express/blocks/playlist/playlist.css
@@ -254,7 +254,7 @@ main .playlist-container .carousel-container .carousel-platform {
     align-items: flex-start;
 }
 
-main .playlist-container .carousel-container span.button.carousel-arrow {
+main .playlist-container .carousel-container a.button.carousel-arrow {
     position: absolute;
     top: 25%;
 }
@@ -316,7 +316,7 @@ main .playlist-container .carousel-container span.button.carousel-arrow {
     main .playlist-container .video-player-video-list-wrapper .video-player-video-list .video-button {
         width: 304px;
     }
-    main .playlist-container .carousel-container span.button.carousel-arrow {
+    main .playlist-container .carousel-container a.button.carousel-arrow {
         position: unset;
         top: unset;
     }

--- a/express/blocks/premium-plan/premium-plan.css
+++ b/express/blocks/premium-plan/premium-plan.css
@@ -238,7 +238,7 @@ main .premium-plan .premium-plan-card ul li a svg {
     max-height: unset;
   }
 
-  main .premium-plan-cards .carousel-container span.button.carousel-arrow {
+  main .premium-plan-cards .carousel-container a.button.carousel-arrow {
     display: none;
   }
 

--- a/express/blocks/premium-plan/premium-plan.css
+++ b/express/blocks/premium-plan/premium-plan.css
@@ -238,7 +238,7 @@ main .premium-plan .premium-plan-card ul li a svg {
     max-height: unset;
   }
 
-  main .premium-plan-cards .carousel-container a.button.carousel-arrow {
+  main .premium-plan-cards .carousel-container span.button.carousel-arrow {
     display: none;
   }
 

--- a/express/blocks/puf/puf.css
+++ b/express/blocks/puf/puf.css
@@ -17,7 +17,7 @@ main .puf.block .carousel-container .carousel-fader-right {
     align-items: flex-start;
 }
 
-main .puf.block .carousel-container span.button.carousel-arrow {
+main .puf.block .carousel-container a.button.carousel-arrow {
     margin-top: calc(100vh / 2);
     position: sticky;
 }

--- a/express/blocks/puf/puf.css
+++ b/express/blocks/puf/puf.css
@@ -17,7 +17,7 @@ main .puf.block .carousel-container .carousel-fader-right {
     align-items: flex-start;
 }
 
-main .puf.block .carousel-container a.button.carousel-arrow {
+main .puf.block .carousel-container span.button.carousel-arrow {
     margin-top: calc(100vh / 2);
     position: sticky;
 }

--- a/express/blocks/seo-nav/seo-nav.css
+++ b/express/blocks/seo-nav/seo-nav.css
@@ -11,7 +11,7 @@ main .seo-nav-container .seo-nav-center-container .carousel-platform {
   padding-top: 6px;
 }
 
-main .seo-nav-container .carousel-container span.button.carousel-arrow {
+main .seo-nav-container .carousel-container a.button.carousel-arrow {
   transform: translateY(-10px);
 }
 

--- a/express/blocks/seo-nav/seo-nav.css
+++ b/express/blocks/seo-nav/seo-nav.css
@@ -11,7 +11,7 @@ main .seo-nav-container .seo-nav-center-container .carousel-platform {
   padding-top: 6px;
 }
 
-main .seo-nav-container .carousel-container a.button.carousel-arrow {
+main .seo-nav-container .carousel-container span.button.carousel-arrow {
   transform: translateY(-10px);
 }
 

--- a/express/blocks/shared/carousel.css
+++ b/express/blocks/shared/carousel.css
@@ -65,7 +65,7 @@ main .carousel-container .carousel-fader-right {
   -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
 
-main .carousel-container span.button.carousel-arrow {
+main .carousel-container a.button.carousel-arrow {
   cursor: pointer;
   display: block;
   float: left;
@@ -89,12 +89,12 @@ main .carousel-container video {
   pointer-events: none;
 }
 
-main .carousel-container .carousel-fader-left.arrow-hidden span.button.carousel-arrow,
-main .carousel-container .carousel-fader-right.arrow-hidden span.button.carousel-arrow {
+main .carousel-container .carousel-fader-left.arrow-hidden a.button.carousel-arrow,
+main .carousel-container .carousel-fader-right.arrow-hidden a.button.carousel-arrow {
   pointer-events: none;
 }
 
-main .carousel-container span.button.carousel-arrow::before {
+main .carousel-container a.button.carousel-arrow::before {
   content: '';
   position: absolute;
   margin-top: 11px;
@@ -104,16 +104,16 @@ main .carousel-container span.button.carousel-arrow::before {
   border-right: solid 2px var(--color-gray-700);
 }
 
-main .carousel-container span.button.carousel-arrow-left::before {
+main .carousel-container a.button.carousel-arrow-left::before {
   margin-left: 13px;
   transform: rotate(-135deg);
 }
 
-main .carousel-container span.button.carousel-arrow-right {
+main .carousel-container a.button.carousel-arrow-right {
   float: right;
 }
 
-main .carousel-container span.button.carousel-arrow-right::before {
+main .carousel-container a.button.carousel-arrow-right::before {
   margin-left: 9px;
   transform: rotate(45deg);
 }
@@ -128,7 +128,7 @@ main .carousel-container.controls-hidden .carousel-platform {
     display: none;
   }
 
-  main .carousel-container span.button.carousel-arrow {
+  main .carousel-container a.button.carousel-arrow {
     margin: 0 10px;
   }
 

--- a/express/blocks/shared/carousel.css
+++ b/express/blocks/shared/carousel.css
@@ -65,7 +65,7 @@ main .carousel-container .carousel-fader-right {
   -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
 
-main .carousel-container a.button.carousel-arrow {
+main .carousel-container span.button.carousel-arrow {
   cursor: pointer;
   display: block;
   float: left;
@@ -89,12 +89,12 @@ main .carousel-container video {
   pointer-events: none;
 }
 
-main .carousel-container .carousel-fader-left.arrow-hidden a.button.carousel-arrow,
-main .carousel-container .carousel-fader-right.arrow-hidden a.button.carousel-arrow {
+main .carousel-container .carousel-fader-left.arrow-hidden span.button.carousel-arrow,
+main .carousel-container .carousel-fader-right.arrow-hidden span.button.carousel-arrow {
   pointer-events: none;
 }
 
-main .carousel-container a.button.carousel-arrow::before {
+main .carousel-container span.button.carousel-arrow::before {
   content: '';
   position: absolute;
   margin-top: 11px;
@@ -104,16 +104,16 @@ main .carousel-container a.button.carousel-arrow::before {
   border-right: solid 2px var(--color-gray-700);
 }
 
-main .carousel-container a.button.carousel-arrow-left::before {
+main .carousel-container span.button.carousel-arrow-left::before {
   margin-left: 13px;
   transform: rotate(-135deg);
 }
 
-main .carousel-container a.button.carousel-arrow-right {
+main .carousel-container span.button.carousel-arrow-right {
   float: right;
 }
 
-main .carousel-container a.button.carousel-arrow-right::before {
+main .carousel-container span.button.carousel-arrow-right::before {
   margin-left: 9px;
   transform: rotate(45deg);
 }
@@ -128,7 +128,7 @@ main .carousel-container.controls-hidden .carousel-platform {
     display: none;
   }
 
-  main .carousel-container a.button.carousel-arrow {
+  main .carousel-container span.button.carousel-arrow {
     margin: 0 10px;
   }
 

--- a/express/blocks/shared/carousel.js
+++ b/express/blocks/shared/carousel.js
@@ -56,8 +56,8 @@ export function buildCarousel(selector = ':scope > *', $parent, infinityScrollEn
   const $faderRight = createTag('div', { class: 'carousel-fader-right' });
   $container.appendChild($faderLeft);
   $container.appendChild($faderRight);
-  const $arrowLeft = createTag('a', { class: 'button carousel-arrow carousel-arrow-left' });
-  const $arrowRight = createTag('a', { class: 'button carousel-arrow carousel-arrow-right' });
+  const $arrowLeft = createTag('span', { class: 'button carousel-arrow carousel-arrow-left' });
+  const $arrowRight = createTag('span', { class: 'button carousel-arrow carousel-arrow-right' });
   $faderLeft.appendChild($arrowLeft);
   $faderRight.appendChild($arrowRight);
 

--- a/express/blocks/shared/carousel.js
+++ b/express/blocks/shared/carousel.js
@@ -56,8 +56,8 @@ export function buildCarousel(selector = ':scope > *', $parent, infinityScrollEn
   const $faderRight = createTag('div', { class: 'carousel-fader-right' });
   $container.appendChild($faderLeft);
   $container.appendChild($faderRight);
-  const $arrowLeft = createTag('span', { class: 'button carousel-arrow carousel-arrow-left' });
-  const $arrowRight = createTag('span', { class: 'button carousel-arrow carousel-arrow-right' });
+  const $arrowLeft = createTag('a', { class: 'button carousel-arrow carousel-arrow-left' });
+  const $arrowRight = createTag('a', { class: 'button carousel-arrow carousel-arrow-right' });
   $faderLeft.appendChild($arrowLeft);
   $faderRight.appendChild($arrowRight);
 

--- a/express/blocks/template-list/template-list.css
+++ b/express/blocks/template-list/template-list.css
@@ -624,8 +624,8 @@ main .template-list.horizontal .carousel-container.controls-hidden .carousel-fad
   pointer-events: none;
 }
 
-main .template-list.horizontal .carousel-container.controls-hidden .carousel-fader-left a.button.carousel-arrow,
-main .template-list.horizontal .carousel-container.controls-hidden .carousel-fader-right a.button.carousel-arrow {
+main .template-list.horizontal .carousel-container.controls-hidden .carousel-fader-left span.button.carousel-arrow,
+main .template-list.horizontal .carousel-container.controls-hidden .carousel-fader-right span.button.carousel-arrow {
   pointer-events: none;
 }
 
@@ -665,8 +665,8 @@ main .template-list.horizontal .carousel-platform {
     opacity: unset;
   }
 
-  main .template-list.horizontal .carousel-container.controls-hidden .carousel-fader-left a.button.carousel-arrow,
-  main .template-list.horizontal .carousel-container.controls-hidden .carousel-fader-right a.button.carousel-arrow {
+  main .template-list.horizontal .carousel-container.controls-hidden .carousel-fader-left span.button.carousel-arrow,
+  main .template-list.horizontal .carousel-container.controls-hidden .carousel-fader-right span.button.carousel-arrow {
     pointer-events: auto;
   }
 
@@ -676,8 +676,8 @@ main .template-list.horizontal .carousel-platform {
     pointer-events: none;
   }
 
-  main .template-list.horizontal .carousel-container .carousel-fader-left.arrow-hidden a.button.carousel-arrow,
-  main .template-list.horizontal .carousel-container .carousel-fader-right.arrow-hidden a.button.carousel-arrow {
+  main .template-list.horizontal .carousel-container .carousel-fader-left.arrow-hidden span.button.carousel-arrow,
+  main .template-list.horizontal .carousel-container .carousel-fader-right.arrow-hidden span.button.carousel-arrow {
     pointer-events: none;
   }
 

--- a/express/blocks/template-list/template-list.css
+++ b/express/blocks/template-list/template-list.css
@@ -624,8 +624,8 @@ main .template-list.horizontal .carousel-container.controls-hidden .carousel-fad
   pointer-events: none;
 }
 
-main .template-list.horizontal .carousel-container.controls-hidden .carousel-fader-left span.button.carousel-arrow,
-main .template-list.horizontal .carousel-container.controls-hidden .carousel-fader-right span.button.carousel-arrow {
+main .template-list.horizontal .carousel-container.controls-hidden .carousel-fader-left a.button.carousel-arrow,
+main .template-list.horizontal .carousel-container.controls-hidden .carousel-fader-right a.button.carousel-arrow {
   pointer-events: none;
 }
 
@@ -665,8 +665,8 @@ main .template-list.horizontal .carousel-platform {
     opacity: unset;
   }
 
-  main .template-list.horizontal .carousel-container.controls-hidden .carousel-fader-left span.button.carousel-arrow,
-  main .template-list.horizontal .carousel-container.controls-hidden .carousel-fader-right span.button.carousel-arrow {
+  main .template-list.horizontal .carousel-container.controls-hidden .carousel-fader-left a.button.carousel-arrow,
+  main .template-list.horizontal .carousel-container.controls-hidden .carousel-fader-right a.button.carousel-arrow {
     pointer-events: auto;
   }
 
@@ -676,8 +676,8 @@ main .template-list.horizontal .carousel-platform {
     pointer-events: none;
   }
 
-  main .template-list.horizontal .carousel-container .carousel-fader-left.arrow-hidden span.button.carousel-arrow,
-  main .template-list.horizontal .carousel-container .carousel-fader-right.arrow-hidden span.button.carousel-arrow {
+  main .template-list.horizontal .carousel-container .carousel-fader-left.arrow-hidden a.button.carousel-arrow,
+  main .template-list.horizontal .carousel-container .carousel-fader-right.arrow-hidden a.button.carousel-arrow {
     pointer-events: none;
   }
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -2155,6 +2155,17 @@ export async function addFreePlanWidget(elem) {
   }
 }
 
+function setLang() {
+  const url = new URL(window.location.href);
+  let lang = 'en';
+  const s = url.pathname.split('/');
+  if (s.length > 1 && s[1].length === 2) {
+    // eslint-disable-next-line prefer-destructuring
+    lang = s[1];
+  }
+  document.documentElement.setAttribute('lang', lang);
+}
+
 /**
  * loads everything that doesn't need to be delayed.
  */
@@ -2171,6 +2182,7 @@ async function loadLazy() {
   addPromotion();
   removeMetadata();
   addFavIcon('/express/icons/cc-express.svg');
+  setLang();
   if (!window.hlx.lighthouse) loadMartech();
 
   sampleRUM('lazy');

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -2156,7 +2156,7 @@ export async function addFreePlanWidget(elem) {
 }
 
 function setLang() {
-  document.documentElement.setAttribute('lang', getLanguage(getLocale(window.location.ref)));
+  document.documentElement.setAttribute('lang', getLanguage(getLocale(window.location)));
 }
 
 /**

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -2156,14 +2156,7 @@ export async function addFreePlanWidget(elem) {
 }
 
 function setLang() {
-  const url = new URL(window.location.href);
-  let lang = 'en';
-  const s = url.pathname.split('/');
-  if (s.length > 1 && s[1].length === 2) {
-    // eslint-disable-next-line prefer-destructuring
-    lang = s[1];
-  }
-  document.documentElement.setAttribute('lang', lang);
+  document.documentElement.setAttribute('lang', getLanguage(getLocale(window.location.ref)));
 }
 
 /**

--- a/test/unit/blocks/expected/how-to-steps-carousel.section.html
+++ b/test/unit/blocks/expected/how-to-steps-carousel.section.html
@@ -6,10 +6,10 @@
     </p>
     <h2>How to title</h2>
     <div class="how-to-steps-carousel">
-      <div class="tip-numbers" aria-role="tablist">
-        <div class="tip-number tip-1 active" tabindex="0" title="1" aria-role="tab" data-tip-index="1"><span>1</span></div>
-        <div class="tip-number tip-2" tabindex="0" title="2" aria-role="tab" data-tip-index="2"><span>2</span></div>
-        <div class="tip-number tip-3" tabindex="0" title="3" aria-role="tab" data-tip-index="3"><span>3</span></div>
+      <div class="tip-numbers" role="tablist">
+        <div class="tip-number tip-1 active" tabindex="0" title="1" role="tab" data-tip-index="1"><span>1</span></div>
+        <div class="tip-number tip-2" tabindex="0" title="2" role="tab" data-tip-index="2"><span>2</span></div>
+        <div class="tip-number tip-3" tabindex="0" title="3" role="tab" data-tip-index="3"><span>3</span></div>
       </div>
       <div class="tips">
         <div class="tip tip-3" data-tip-index="3">

--- a/test/unit/blocks/expected/template-list.horizontal.block.html
+++ b/test/unit/blocks/expected/template-list.horizontal.block.html
@@ -152,7 +152,7 @@
         </div>
         <div><span class="template-link">Edit this template</span></div>
       </a></div>
-    <div class="carousel-fader-left"><a class="button carousel-arrow carousel-arrow-left"></a></div>
-    <div class="carousel-fader-right"><a class="button carousel-arrow carousel-arrow-right"></a></div>
+    <div class="carousel-fader-left"><span class="button carousel-arrow carousel-arrow-left"></span></div>
+    <div class="carousel-fader-right"><span class="button carousel-arrow carousel-arrow-right"></span></div>
   </div>
 </div>


### PR DESCRIPTION
You need to open the PageSpeed test page to see the improvements but this is the current status for the flyer page on adobe.com:

![image](https://user-images.githubusercontent.com/474200/197992858-876027c0-e6da-4db6-84f8-4f514fb8193c.png)

Accessibly: 82
SEO: 84

We must do better.

With those few changes, I now reach:

![image](https://user-images.githubusercontent.com/474200/198000807-49c29b18-9493-4771-9c74-6115a0c87fb2.png)

The 84 vs 84 for SEO is mainly due to the no-index on hlx.live. On .live we went from 77 to 84 with the changes and hope to go above 90 on prod.

Impact on the DOM:
- `ul.ctaswrapper` is now `div.ctaswrapper` (Google complains about a `ul` without `li`- which in that case does not make any sense)
- `a.button.carousel-arrow` is now `span.button.carousel-arrow` (the `a` tag does not have an href - and does not need one - but that's an SEO issue - links following)

The next steps are more complex / tricky:

- Accessibility:
  - Only remains Heading elements are not in a sequentially-descending order - we have an H5 at the top, not sure if this is really important to fix.
  - `Background and foreground colors do not have a sufficient contrast ratio.` - something to bring to designers attention.
- SEO
  - Links do not have descriptive text - this is the Learn More text on the Illustrator link at the bottom of the page. This is content, we might need to tell the Business that this is a bad practice for SEO (see https://web.dev/link-text/?utm_source=lighthouse&utm_medium=lr for reference)
  - Links are not crawlable - that's a risky one - the carousel arrows uses <a> tags without an href. This should not be <a> tags at all I think but changing it has a lot of impact since this is used in many places and they leverage the a.button class. This change must be tested in depth.
  - Mobile friendly: Tap targets are not sized appropriately - important to raise to designers - see https://web.dev/tap-targets/

Test page: https://improve-seo-access--express-website--adobe.hlx.live/express/create/flyer?lighthouse=on