### PR TITLE
fix: floating button in ToC challengers

### DIFF
--- a/express/experiments/ccx0074/blocks/toc1/toc.css
+++ b/express/experiments/ccx0074/blocks/toc1/toc.css
@@ -200,7 +200,3 @@ main .floating-button .floating-button-lottie {
 main .floating-button a.button:any-link {
   margin-right: 0;
 }
-
-main .toc-container.open ~ .floating-button-wrapper.multifunction::before {
-  display: none;
-}

--- a/express/experiments/ccx0074/blocks/toc1/toc.css
+++ b/express/experiments/ccx0074/blocks/toc1/toc.css
@@ -200,3 +200,7 @@ main .floating-button .floating-button-lottie {
 main .floating-button a.button:any-link {
   margin-right: 0;
 }
+
+main .toc-container.open ~ .floating-button-wrapper.multifunction::before {
+  display: none;
+}

--- a/express/experiments/ccx0074/blocks/toc1/toc.css
+++ b/express/experiments/ccx0074/blocks/toc1/toc.css
@@ -192,3 +192,11 @@ main .toc-container.open .template-title p:first-child {
 main .toc-container.open ~ .floating-button-wrapper {
   background: none;
 }
+
+main .floating-button .floating-button-lottie {
+  display: none;
+}
+
+main .floating-button a.button:any-link {
+  margin-right: 0;
+}

--- a/express/experiments/ccx0074/blocks/toc2/toc.css
+++ b/express/experiments/ccx0074/blocks/toc2/toc.css
@@ -223,3 +223,11 @@ main .toc-container.open .toc-close {
 main .toc-container.open ~ .floating-button-wrapper {
   background: none;
 }
+
+main .floating-button .floating-button-lottie {
+  display: none;
+}
+
+main .floating-button a.button:any-link {
+  margin-right: 0;
+}

--- a/express/experiments/ccx0074/blocks/toc2/toc.css
+++ b/express/experiments/ccx0074/blocks/toc2/toc.css
@@ -231,3 +231,7 @@ main .floating-button .floating-button-lottie {
 main .floating-button a.button:any-link {
   margin-right: 0;
 }
+
+main .toc-container.open ~ .floating-button-wrapper.multifunction::before {
+  display: none;
+}

--- a/express/experiments/ccx0074/blocks/toc2/toc.css
+++ b/express/experiments/ccx0074/blocks/toc2/toc.css
@@ -231,7 +231,3 @@ main .floating-button .floating-button-lottie {
 main .floating-button a.button:any-link {
   margin-right: 0;
 }
-
-main .toc-container.open ~ .floating-button-wrapper.multifunction::before {
-  display: none;
-}


### PR DESCRIPTION
> [@skelley](https://cq-dev.slack.com/team/WAPELB17Y) flagged a bug in the Table of Contents experience that needs addressing:
> ![File](https://user-images.githubusercontent.com/1235810/200897830-5440b00e-202f-4256-82b3-721f104cfc0b.jpg)
> When the Table of Contents is present, the bobbing arrow in the bottom CTA should be removed. Would that be possible to update in the code for the experiment? that applies to both Ch1 and Ch2

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/create/flyer
- After: https://fix-toc--express-website--adobe.hlx.page/express/create/flyer
