### PR TITLE
fix: adjust ToC overlay background to hide floating button background

### DIFF
--- a/express/experiments/ccx0074/blocks/toc1/toc.css
+++ b/express/experiments/ccx0074/blocks/toc1/toc.css
@@ -53,7 +53,7 @@ main .toc-container.open .toc-wrapper {
 
 main .toc-container.open .toc-wrapper:before {
   content: '';
-  background: rgba(0,0,0,.75);
+  background: linear-gradient(180deg, rgba(0,0,0,.75) 0%, rgba(0,0,0,.75) 82%, rgba(64,64,64,1) 95%);
   top: 0;
   height: 100vh;
   width: 100%;
@@ -199,4 +199,8 @@ main .floating-button .floating-button-lottie {
 
 main .floating-button a.button:any-link {
   margin-right: 0;
+}
+
+main .toc-container.open ~ .floating-button-wrapper.multifunction::before {
+  display: none;
 }

--- a/express/experiments/ccx0074/blocks/toc2/toc.css
+++ b/express/experiments/ccx0074/blocks/toc2/toc.css
@@ -65,7 +65,7 @@ main .toc-container.open .toc-wrapper:before {
   width: 100%;
   z-index: 1;
   content: '';
-  background: rgba(0,0,0,.8);
+  background: linear-gradient(180deg, rgba(0,0,0,.8) 0%, rgba(0,0,0,.8) 82%, rgba(51,51,51,1) 95%);
 }
 
 main .toc-container .toc {
@@ -230,4 +230,8 @@ main .floating-button .floating-button-lottie {
 
 main .floating-button a.button:any-link {
   margin-right: 0;
+}
+
+main .toc-container.open ~ .floating-button-wrapper.multifunction::before {
+  display: none;
 }


### PR DESCRIPTION
When the ToC experiments for CCX0074 are open, the overlay is sitting below the white gradient background of the floating button. This PR addresses the issue

Before/after:
<img width="300" alt="Screen Shot 2022-11-09 at 7 56 03 PM" src="https://user-images.githubusercontent.com/1235810/200917224-d509f2c2-4b5e-4b62-b02b-abab426f57e1.png"> <img width="300" alt="Screen Shot 2022-11-09 at 7 56 13 PM" src="https://user-images.githubusercontent.com/1235810/200917210-c93a0578-213a-4d53-8f86-f622b7b2af42.png">
<img width="300" alt="Screen Shot 2022-11-09 at 7 59 34 PM" src="https://user-images.githubusercontent.com/1235810/200917698-fef6b1e1-1795-461c-ac1a-a588a2e92e55.png"> <img width="300" alt="Screen Shot 2022-11-09 at 7 59 40 PM" src="https://user-images.githubusercontent.com/1235810/200917695-e7bdaed6-7e8f-43d4-ad6f-9f3ca391c53a.png">


Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/
- After:
  - https://fix-toc-background--express-website--adobe.hlx.live/express/create/flyer?experiment=ccx0074%2Fchallenger-1
  - https://fix-toc-background--express-website--adobe.hlx.live/express/create/flyer?experiment=ccx0074%2Fchallenger-2
