### PR TITLE
feat: basic image views tracking on the data layer

### DIFF
--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -1025,7 +1025,7 @@ loadScript(martechURL, () => {
   }
 
   const processed = {};
-  function initHemingway() {
+  function initDataLayerPoller() {
     // poll the dataLayer every 2 seconds
     setInterval(() => {
       // loop through each of the events in the dataLayer
@@ -1077,7 +1077,7 @@ loadScript(martechURL, () => {
   }
 
   decorateAnalyticsEvents();
-  initHemingway();
+  initDataLayerPoller();
 
   const ENABLE_PRICING_MODAL_AUDIENCE = 'enablePricingModal';
   const RETURNING_VISITOR_SEGMENT_ID = 23153796;

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -1024,8 +1024,6 @@ loadScript(martechURL, () => {
     });
   }
 
-  
-
   const processed = {};
   function initHemingway() {
     // poll the dataLayer every 2 seconds

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -1025,7 +1025,7 @@ loadScript(martechURL, () => {
   }
 
   const processed = {};
-  function initDataLayerPoller() {
+  function initHemingway() {
     // poll the dataLayer every 2 seconds
     setInterval(() => {
       // loop through each of the events in the dataLayer
@@ -1077,7 +1077,7 @@ loadScript(martechURL, () => {
   }
 
   decorateAnalyticsEvents();
-  initDataLayerPoller();
+  initHemingway();
 
   const ENABLE_PRICING_MODAL_AUDIENCE = 'enablePricingModal';
   const RETURNING_VISITOR_SEGMENT_ID = 23153796;

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -1024,7 +1024,62 @@ loadScript(martechURL, () => {
     });
   }
 
+  
+
+  const processed = {};
+  function initHemingway() {
+    // poll the dataLayer every 2 seconds
+    setInterval(() => {
+      // loop through each of the events in the dataLayer
+      window.dataLayer.forEach((evt) => {
+        // don't continue if it has already been processed
+        if (processed[evt.assetId]) {
+          return;
+        }
+        // mark as processed
+        processed[evt.assetId] = 1;
+        // track a new event
+        if (useAlloy) {
+          _satellite.track('event', {
+            data: {
+              eventType: 'web.webinteraction.linkClicks',
+              web: {
+                webInteraction: {
+                  name: 'assetView',
+                  linkClicks: {
+                    value: 1,
+                  },
+                  type: 'other',
+                },
+              },
+              _adobe_corpnew: {
+                digitalData: {
+                  primaryEvent: {
+                    eventInfo: {
+                      eventName: 'assetView',
+                    },
+                  },
+                  spark: {
+                    eventData: {
+                      eventName: 'assetView',
+                      sendTimestamp: Date.now(),
+                    },
+                  },
+                  hemingway: {
+                    assetId: evt.assetId,
+                    assetPath: evt.assetPath,
+                  },
+                },
+              },
+            },
+          });
+        }
+      });
+    }, 2000);
+  }
+
   decorateAnalyticsEvents();
+  initHemingway();
 
   const ENABLE_PRICING_MODAL_AUDIENCE = 'enablePricingModal';
   const RETURNING_VISITOR_SEGMENT_ID = 23153796;

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -125,7 +125,6 @@ function trackViewedAssetsInDataLayer(assetsSelector = 'img[src*="/media_"]') {
           || el.src; // the source for an image/video/iframe
         assetPath = new URL(assetPath).pathname;
         const match = assetPath.match(/media_([a-f0-9]+)\.\w+/);
-        const assetId = match ? match[1] : assetPath;
         const assetFilename = match ? match[0] : assetPath;
         const details = {
           event: 'viewasset',

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -124,11 +124,12 @@ function trackViewedAssetsInDataLayer(assetsSelector = 'img[src*="/media_"]') {
           || el.currentSrc // the active source in a picture/video/audio element
           || el.src; // the source for an image/video/iframe
         assetPath = new URL(assetPath).pathname;
-        const match = assetPath.match(/media_([a-f0-9]+)\./);
+        const match = assetPath.match(/media_([a-f0-9]+)\.\w+/);
         const assetId = match ? match[1] : assetPath;
+        const assetFilename = match ? match[0] : assetPath;
         const details = {
           event: 'viewasset',
-          assetId,
+          assetId: assetFilename,
           assetPath,
         };
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -152,19 +152,17 @@ function trackViewedAssetsInDataLayer(assetsSelector = 'img[src*="/media_"]') {
         if (n.nodeType === Node.TEXT_NODE) {
           return;
         }
-        const img = n.querySelector(assetsSelector);
-        if (img) {
-          viewAssetObserver.unobserve(img);
-        }
+        n.querySelectorAll(assetsSelector).forEach((asset) => {
+          viewAssetObserver.unobserve(asset);
+        });
       });
       mutation.addedNodes.forEach((n) => {
         if (n.nodeType === Node.TEXT_NODE) {
           return;
         }
-        const img = n.querySelector(assetsSelector);
-        if (img) {
-          viewAssetObserver.observe(img);
-        }
+        n.querySelectorAll(assetsSelector).forEach((asset) => {
+          viewAssetObserver.observe(asset);
+        });
       });
     });
   }).observe(document.body, { childList: true, subtree: true });

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -119,8 +119,11 @@ function trackViewedAssetsInDataLayer(assetsSelector = 'img[src*="/media_"]') {
         // observe only once
         viewAssetObserver.unobserve(el);
 
-        // Get asset detais
-        const assetPath = new URL(el.href || el.currentSrc || el.src).pathname;
+        // Get asset details
+        let assetPath = el.href // the reference for an a/svg tag
+          || el.currentSrc // the active source in a picture/video/audio element
+          || el.src; // the source for an image/video/iframe
+        assetPath = new URL(assetPath).pathname;
         const match = assetPath.match(/media_([a-f0-9]+)\./);
         const assetId = match ? match[1] : assetPath;
         const details = {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -119,15 +119,22 @@ function trackViewedAssetsInDataLayer(assetsSelector = 'img[src*="/media_"]') {
         // observe only once
         viewAssetObserver.unobserve(el);
 
+        // Get asset detais
         const assetPath = new URL(el.href || el.currentSrc || el.src).pathname;
         const match = assetPath.match(/media_([a-f0-9]+)\./);
         const assetId = match ? match[1] : assetPath;
-
         const details = {
           event: 'viewasset',
           assetId,
           assetPath,
         };
+
+        // Add experiment details
+        const { id, selectedVariant } = (window.hlx.experiment || {});
+        if (selectedVariant) {
+          details.experiment = id;
+          details.variant = selectedVariant;
+        }
 
         window.dataLayer.push(details);
       });

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -141,22 +141,24 @@ function trackViewedAssetsInDataLayer(assetsSelector = 'img[src*="/media_"]') {
   // Observe all assets added async
   new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
-      mutation.removedNodes
-        .filter((n) => n.nodeType !== Node.TEXT_NODE)
-        .forEach((n) => {
-          const img = n.querySelector(assetsSelector);
-          if (img) {
-            viewAssetObserver.unobserve(img);
-          }
-        });
-      mutation.addedNodes
-        .filter((n) => n.nodeType !== Node.TEXT_NODE)
-        .forEach((n) => {
-          const img = n.querySelector(assetsSelector);
-          if (img) {
-            viewAssetObserver.observe(img);
-          }
-        });
+      mutation.removedNodes.forEach((n) => {
+        if (n.nodeType === Node.TEXT_NODE) {
+          return;
+        }
+        const img = n.querySelector(assetsSelector);
+        if (img) {
+          viewAssetObserver.unobserve(img);
+        }
+      });
+      mutation.addedNodes.forEach((n) => {
+        if (n.nodeType === Node.TEXT_NODE) {
+          return;
+        }
+        const img = n.querySelector(assetsSelector);
+        if (img) {
+          viewAssetObserver.observe(img);
+        }
+      });
     });
   }).observe(document.body, { childList: true, subtree: true });
 }


### PR DESCRIPTION
As part of a PoC for Hemingway, we want to track image views via a generic data layer so that the alloy instrumentation can pick those events up async.

Test URLs:
- Before: https://main--express-website--adobe.hlx.live/express/create/flyer
- After: https://hemingway-poc--express-website--adobe.hlx.live/express/create/flyer?lighthouse=on
