### PR TITLE
fix: break long words and don't clip button texts

### DIFF
--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -451,6 +451,7 @@ h6 {
   font-weight: var(--heading-font-weight);
   line-height: var(--heading-line-height);
   hyphens: auto;
+  --webkit-hyphens: auto; /* safari */
 }
 
 main h1 {

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -450,8 +450,9 @@ h5,
 h6 {
   font-weight: var(--heading-font-weight);
   line-height: var(--heading-line-height);
+  overflow-wrap: anywhere;
+  -webkit-hyphens: auto; /* safari */
   hyphens: auto;
-  --webkit-hyphens: auto; /* safari */
 }
 
 main h1 {

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -173,10 +173,10 @@ a.button:any-link {
   border-width: 2px;
   border-style: solid;
   margin: 10px;
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   display: inline-block;
+
 }
 
 a.button.xlarge:any-link {
@@ -450,6 +450,7 @@ h5,
 h6 {
   font-weight: var(--heading-font-weight);
   line-height: var(--heading-line-height);
+  hyphens: auto;
 }
 
 main h1 {


### PR DESCRIPTION
- Long words in headings can spill over, those should be broken with hyphens.
- Long button texts get cut off, those should be wrapped to a second line instead

@skelleyadobe  @timliu-adobe 

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/drafts/rofe/feature/content-scheduler
- After: https://overflow-fix--express-website--adobe.hlx.page/drafts/rofe/feature/content-scheduler?lighthouse=on
