### PR TITLE
[MWPW-113214] Hide Top Templates block when empty

### DIFF
--- a/express/scripts/templates.js
+++ b/express/scripts/templates.js
@@ -107,14 +107,13 @@ function updateBlocks(data) {
   if (seoNav) {
     const topTemplatesContainer = seoNav.querySelector('p').parentElement;
 
-    if (window.templates.data && data.topTemplates) {
+    if (data.topTemplates) {
       const topTemplatesTemplate = seoNav.querySelector('p').cloneNode(true);
       const topTemplatesData = data.topTemplates.split(', ');
 
       updateLinkList(topTemplatesContainer, topTemplatesTemplate, topTemplatesData);
     } else {
-      topTemplatesContainer.innerHTML = ''; //I think we can take out this line?
-      seoNav.style.display = 'none';
+      topTemplatesContainer.innerHTML = '';
     }
 
     if (data.topTemplatesTitle) {
@@ -125,6 +124,10 @@ function updateBlocks(data) {
       seoNav.innerHTML = seoNav.innerHTML.replace('Default top templates text', data.topTemplatesText);
     } else {
       seoNav.innerHTML = seoNav.innerHTML.replace('Default top templates text', '');
+    }
+
+    if (!data.topTemplates && !data.topTemplatesTitle && !data.topTemplatesText) {
+      seoNav.remove()
     }
   }
 }

--- a/express/scripts/templates.js
+++ b/express/scripts/templates.js
@@ -107,9 +107,6 @@ function updateBlocks(data) {
   if (seoNav) {
     const topTemplatesContainer = seoNav.querySelector('p').parentElement;
 
-    const buttons = seoNav.querySelector('p')
-    console.log(buttons.innerHTML)
-
     if (window.templates.data && data.topTemplates) {
       const topTemplatesTemplate = seoNav.querySelector('p').cloneNode(true);
       const topTemplatesData = data.topTemplates.split(', ');
@@ -129,10 +126,6 @@ function updateBlocks(data) {
     } else {
       seoNav.innerHTML = seoNav.innerHTML.replace('Default top templates text', '');
     }
-
-    console.log(`Top Templates: ${data.topTemplates}`)
-    console.log(`Top Templates Title: ${data.topTemplatesTitle}`)
-    console.log(`Top Templates Text: ${data.topTemplatesText}`)
   }
 }
 

--- a/express/scripts/templates.js
+++ b/express/scripts/templates.js
@@ -107,13 +107,17 @@ function updateBlocks(data) {
   if (seoNav) {
     const topTemplatesContainer = seoNav.querySelector('p').parentElement;
 
+    const buttons = seoNav.querySelector('p')
+    console.log(buttons.innerHTML)
+
     if (window.templates.data && data.topTemplates) {
       const topTemplatesTemplate = seoNav.querySelector('p').cloneNode(true);
       const topTemplatesData = data.topTemplates.split(', ');
 
       updateLinkList(topTemplatesContainer, topTemplatesTemplate, topTemplatesData);
     } else {
-      topTemplatesContainer.innerHTML = '';
+      topTemplatesContainer.innerHTML = ''; //I think we can take out this line?
+      seoNav.style.display = 'none';
     }
 
     if (data.topTemplatesTitle) {
@@ -125,6 +129,10 @@ function updateBlocks(data) {
     } else {
       seoNav.innerHTML = seoNav.innerHTML.replace('Default top templates text', '');
     }
+
+    console.log(`Top Templates: ${data.topTemplates}`)
+    console.log(`Top Templates Title: ${data.topTemplatesTitle}`)
+    console.log(`Top Templates Text: ${data.topTemplatesText}`)
   }
 }
 


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://jira.corp.adobe.com/browse/MWPW-113214

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/templates/bingo-card
- After: https://mwpw-113214-fix--express-website--webistry-development.hlx.page/express/templates/bingo-card

This edit to the code will make it so that the topTemplatesBlock is hide able by omitting to fill out the required columns. For the "Top Templates" block to be hidden, it's necessary that all three columns named "topTemplatesTitle", "topTemplatesText" and "topTemplates" are completely empty.
