### PR TITLE
feat(templates): allow up to 10,000 rows

### DIFF
--- a/express/scripts/templates.js
+++ b/express/scripts/templates.js
@@ -17,7 +17,7 @@ import {
 async function fetchPageContent(path) {
   if (!(window.templates && window.templates.data)) {
     window.templates = {};
-    const resp = await fetch('/express/templates/content.json?sheet=seo-templates&limit=100000');
+    const resp = await fetch('/express/templates/content.json?sheet=seo-templates&limit=10000');
     window.templates.data = resp.ok ? (await resp.json()).data : [];
   }
 

--- a/express/scripts/templates.js
+++ b/express/scripts/templates.js
@@ -17,7 +17,7 @@ import {
 async function fetchPageContent(path) {
   if (!(window.templates && window.templates.data)) {
     window.templates = {};
-    const resp = await fetch('/express/templates/content.json?sheet=seo-templates');
+    const resp = await fetch('/express/templates/content.json?sheet=seo-templates&limit=100000');
     window.templates.data = resp.ok ? (await resp.json()).data : [];
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -936,6 +936,7 @@
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
       }
+        {
     },
     "node_modules/chai": {
       "version": "4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -936,7 +936,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
       }
-        {
     },
     "node_modules/chai": {
       "version": "4.3.4",


### PR DESCRIPTION
Increasing the limit of the templates 

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/de/express/templates/banner/twitter-header
- After: https://templates-limit-fix--express-website--webistry-development.hlx.page/de/express/templates/banner/twitter-header?lighthouse=on

This page specifically doesn't work on the main branch due to the 1,000 limit, whereas on my branch link it will work because the limit is now 100,000. 
