### PR TITLE
fix(templates-list): change animation intake method

### DIFF
--- a/express/blocks/shared/background-animations.js
+++ b/express/blocks/shared/background-animations.js
@@ -11,27 +11,17 @@
  */
 import { createTag } from '../../scripts/scripts.js';
 
-export default function addBackgroundAnimation($block, animationName) {
+export default function addBackgroundAnimation($block, animationUrl) {
   const $videoBackground = createTag('video', {
     class: 'snow-background', autoplay: true, muted: true, loop: true, playsinline: true,
   });
 
-  const animations = {
-    firework: function startFirework($section) {
-      $section.classList.add('firework');
-    },
-    snow: function startSnowing($section) {
-      $section.classList.add('snowing');
-      $videoBackground.classList.add('snow-background');
-      $videoBackground.append(createTag('source', { src: 'https://www.adobe.com/express/media_18115ed8a55cc84ae354bdd375d8057198f3f720e.mp4', type: 'video/mp4' }));
-      $section.prepend($videoBackground);
-    },
-  };
-
   const $parent = $block.closest('.section');
 
   if ($parent) {
-    animations[animationName]($parent);
-    $videoBackground.play();
+    $parent.classList.add('with-animation');
+    $videoBackground.classList.add('snow-background');
+    $videoBackground.append(createTag('source', { src: animationUrl, type: 'video/mp4' }));
+    $parent.prepend($videoBackground);
   }
 }

--- a/express/blocks/template-list/template-list.css
+++ b/express/blocks/template-list/template-list.css
@@ -926,12 +926,7 @@ main .template-list-horizontal-apipowered-holiday-container {
   background: var(--color-black);
 }
 
-main .template-list-horizontal-apipowered-holiday-container.firework {
-  color: var(--color-white);
-  padding-top: 0;
-}
-
-main .template-list-horizontal-apipowered-holiday-container.snowing {
+main .template-list-horizontal-apipowered-holiday-container.with-animation {
   color: var(--color-white);
   padding-top: 0;
 }


### PR DESCRIPTION
Fix templates-list holiday variant: Changing the way of authoring background animation from name to video url (no ticket)

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/drafts/qiyundai/create/flyer1
- Before: https://main--express-website--adobe.hlx.page/drafts/qiyundai/flyer2
- After: https://animation-by-url--express-website--webistry-development.hlx.page/drafts/qiyundai/create/flyer1?lighthouse=on
- After: https://animation-by-url--express-website--webistry-development.hlx.page/drafts/qiyundai/create/flyer2?lighthouse=on
