### PR TITLE
fix(app-store-blade): replacing a flexbox with inline-blocks

### DIFF
--- a/express/blocks/app-store-blade/app-store-blade.css
+++ b/express/blocks/app-store-blade/app-store-blade.css
@@ -35,7 +35,6 @@ main .app-store-blade-container .main-container .heading span {
 }
 
 main .app-store-blade-container .main-container .body {
-    display: flex;
     width: 680px;
     max-height: 167px;
     text-align: left;
@@ -43,8 +42,9 @@ main .app-store-blade-container .main-container .body {
     z-index: 1;
 }
 
-main .app-store-blade-container .main-container .qr-code picture {
-    min-height: 191px;
+main .app-store-blade-container .main-container .qr-code {
+    min-width: 191px;
+    display: inline-block;
 }
 
 main .app-store-blade-container .main-container .qr-code img {
@@ -53,6 +53,10 @@ main .app-store-blade-container .main-container .qr-code img {
     height: 100%;
     padding-right: 24px;
     display: block;
+}
+
+main .app-store-blade-container .main-container .body-content-wrapper {
+    display: inline-block;
 }
 
 main .app-store-blade-container .main-container .copy-wrapper p {

--- a/express/blocks/app-store-blade/app-store-blade.css
+++ b/express/blocks/app-store-blade/app-store-blade.css
@@ -50,7 +50,6 @@ main .app-store-blade-container .main-container .qr-code {
 main .app-store-blade-container .main-container .qr-code img {
     object-fit: contain;
     max-width: 167px;
-    height: 100%;
     padding-right: 24px;
     display: block;
 }

--- a/express/blocks/app-store-blade/app-store-blade.css
+++ b/express/blocks/app-store-blade/app-store-blade.css
@@ -43,6 +43,10 @@ main .app-store-blade-container .main-container .body {
     z-index: 1;
 }
 
+main .app-store-blade-container .main-container .qr-code picture {
+    min-height: 191px;
+}
+
 main .app-store-blade-container .main-container .qr-code img {
     object-fit: contain;
     max-width: 167px;


### PR DESCRIPTION
Fix App Store Blade (no ticket)

The App Store Blade flexbox was buggy on Safari. Resorting to using inline-blocks.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/create/post/instagram
- After: https://app-blade-fix--express-website--webistry-development.hlx.page/express/create/post/instagram?lighthouse=on
