### PR TITLE
chore: remove horizontal wrapper padding on mobile

### DIFF
--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -726,7 +726,7 @@ main .section {
 main .section>div {
   margin: auto;
   max-width: 375px;
-  padding: 0 32px;
+  padding: 0;
 }
 
 main .section>div:empty {


### PR DESCRIPTION
Removing the extra lateral padding helps minimize hyphenation on mobile.

Test URLs:
- Before: https://www.adobe.com/es/express/create/business-card/dj
- After: https://no-wrapper-padding--express-website--adobe.hlx.page/es/express/create/business-card/dj?lighthouse=on
