### PR TITLE
fix: PUF block is followed by a huge whitespace on mobile

### DIFF
--- a/express/blocks/puf/puf.js
+++ b/express/blocks/puf/puf.js
@@ -328,7 +328,7 @@ function updatePUFCarousel($block) {
   $carouselContainer.classList.add('slide-1-selected');
   const slideFunctionality = () => {
     $carouselPlatform.scrollLeft = $carouselPlatform.offsetWidth;
-    $carouselContainer.style.minHeight = `${$rightCard.clientHeight + 40}px`;
+    $carouselContainer.style.minHeight = `${$leftCard.clientHeight + 40}px`;
     const $rightArrow = $carouselContainer.querySelector('.carousel-fader-right');
     const $leftArrow = $carouselContainer.querySelector('.carousel-fader-left');
     const changeSlide = (index) => {
@@ -385,7 +385,7 @@ function updatePUFCarousel($block) {
       clearInterval(waitForCardsToLoad);
       slideFunctionality();
     }
-  }, 200);
+  }, 400);
 }
 
 export default function decorate($block) {


### PR DESCRIPTION
This is what the pricing page randomly looks like on mobile:

<img width="935" alt="image" src="https://user-images.githubusercontent.com/474200/204758529-f2830ee1-7fb6-4453-b8ee-da084a8d662f.png">


Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/pricing
- After: https://fix-puf--express-website--adobe.hlx.page/express/pricing?lighthouse=on
