### PR TITLE
fix(auto-multifunction-button): async bug fix

### DIFF
--- a/express/blocks/floating-button/floating-button.js
+++ b/express/blocks/floating-button/floating-button.js
@@ -355,8 +355,8 @@ function collectMultifunctionData($block, dataArray) {
 
       for (let i = 1; i < 7; i += 1) {
         if (key === `cta ${i} icon`) {
-          const href = array[index + 1][1];
-          const text = array[index + 2][1];
+          const [, href] = array[index + 1];
+          const [, text] = array[index + 2];
           const $icon = getIconElement(value);
           const $a = createTag('a', { title: text, href });
           $a.textContent = text;

--- a/express/blocks/floating-button/floating-button.js
+++ b/express/blocks/floating-button/floating-button.js
@@ -19,6 +19,7 @@ import {
   getMetadata,
   lazyLoadLottiePlayer,
   loadCSS,
+  fetchMultifunctionButton,
 } from '../../scripts/scripts.js';
 
 let scrollState = 'withLottie';
@@ -322,7 +323,7 @@ function buildToolBox($wrapper, data) {
   initNotchDragAction($wrapper);
 }
 
-function collectMultifunctionData($block) {
+function collectMultifunctionData($block, dataArray) {
   const data = {
     single: 'N',
     delay: 3,
@@ -332,12 +333,9 @@ function collectMultifunctionData($block) {
   };
 
   if ($block.className.includes('spreadsheet-powered')) {
-    // TODO: build tools using data from sheet
-    const $cols = $block.querySelectorAll(':scope > div');
-    $cols.forEach(($col, index, array) => {
-      const fields = $col.querySelectorAll(':scope > div');
-      const key = fields[0].textContent;
-      const value = fields[1].textContent;
+    dataArray.forEach((col, index, array) => {
+      const key = col[0];
+      const value = col[1];
 
       if (key === 'single') {
         data.single = value;
@@ -357,8 +355,8 @@ function collectMultifunctionData($block) {
 
       for (let i = 1; i < 7; i += 1) {
         if (key === `cta ${i} icon`) {
-          const href = array[index + 1].querySelector(':scope > div:last-of-type').textContent;
-          const text = array[index + 2].querySelector(':scope > div:last-of-type').textContent;
+          const href = array[index + 1][1];
+          const text = array[index + 2][1];
           const $icon = getIconElement(value);
           const $a = createTag('a', { title: text, href });
           $a.textContent = text;
@@ -410,27 +408,29 @@ function makeCTAFromSheet($block, data) {
 }
 
 export async function createMultiFunctionButton($block, data) {
-  const $existingFloatingButtons = document.querySelectorAll('.floating-button-wrapper');
-  if ($existingFloatingButtons) {
-    $existingFloatingButtons.forEach(($button) => {
-      if (!$button.dataset.audience) {
-        $button.dataset.audience = 'desktop';
-        $button.dataset.sectionStatus = 'loaded';
-      } else if ($button.dataset.audience === 'mobile') {
-        $button.remove();
-      }
-    });
+  if (data.tools.length > 0) {
+    const $existingFloatingButtons = document.querySelectorAll('.floating-button-wrapper');
+    if ($existingFloatingButtons) {
+      $existingFloatingButtons.forEach(($button) => {
+        if (!$button.dataset.audience) {
+          $button.dataset.audience = 'desktop';
+          $button.dataset.sectionStatus = 'loaded';
+        } else if ($button.dataset.audience === 'mobile') {
+          $button.remove();
+        }
+      });
+    }
+
+    const $ctaContainer = $block.querySelector('.button-container');
+    const $cta = $ctaContainer.querySelector('a');
+    const $buttonWrapper = await createFloatingButton(
+      $cta,
+      'mobile',
+    ).then(((result) => result));
+
+    $buttonWrapper.classList.add('multifunction');
+    buildToolBox($buttonWrapper, data);
   }
-
-  const $ctaContainer = $block.querySelector('.button-container');
-  const $cta = $ctaContainer.querySelector('a');
-  const $buttonWrapper = await createFloatingButton(
-    $cta,
-    'mobile',
-  ).then(((result) => result));
-
-  $buttonWrapper.classList.add('multifunction');
-  buildToolBox($buttonWrapper, data);
 }
 
 export default async function decorateBlock($block) {
@@ -438,7 +438,21 @@ export default async function decorateBlock($block) {
   const $parentSection = $block.closest('.section');
 
   if (['yes', 'true', 'on'].includes(getMetadata('show-multifunction-button')) || Array.from($block.children).length > 1) {
-    const data = collectMultifunctionData($block);
+    const multifunctionButton = await fetchMultifunctionButton(window.location.pathname);
+    const buttonParameters = [];
+
+    if (multifunctionButton) {
+      const defaultButton = await fetchMultifunctionButton('default');
+      const objectKeys = Object.keys(defaultButton);
+
+      // eslint-disable-next-line consistent-return
+      objectKeys.forEach((key) => {
+        if (['path', 'live'].includes(key)) return false;
+        buttonParameters.push([key, multifunctionButton[key] || defaultButton[key]]);
+      });
+    }
+
+    const data = collectMultifunctionData($block, buttonParameters);
 
     if (!$a && data.mainCta.href) {
       $a = makeCTAFromSheet($block, data);

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1596,6 +1596,12 @@ function buildAutoBlocks($main) {
     const $plansComparison = buildBlock('plans-comparison', '');
     $main.querySelector(':scope > div:last-of-type').append($plansComparison);
   }
+
+  if (['yes', 'true', 'on'].includes(getMetadata('show-multifunction-button').toLowerCase())) {
+    const $multifunctionButton = buildBlock('floating-button', '');
+    $multifunctionButton.classList.add('spreadsheet-powered');
+    $main.querySelector(':scope > div:last-of-type').append($multifunctionButton);
+  }
 }
 
 function splitSections($main) {
@@ -1883,7 +1889,7 @@ function decoratePictures(main) {
   });
 }
 
-async function fetchMultifunctionButton(path) {
+export async function fetchMultifunctionButton(path) {
   if (!window.multifunctionButton) {
     try {
       const locale = getLocale(window.location);
@@ -1910,33 +1916,8 @@ async function fetchMultifunctionButton(path) {
   return null;
 }
 
-async function buildAsyncAutoBlocks($main) {
-  // load the multifunction-button autoblock
-  if (['yes', 'true', 'on'].includes(getMetadata('show-multifunction-button').toLowerCase())) {
-    const multifunctionButton = await fetchMultifunctionButton(window.location.pathname);
-
-    if (multifunctionButton) {
-      const defaultButton = await fetchMultifunctionButton('default');
-      const objectKeys = Object.keys(defaultButton);
-
-      const buttonParameters = [];
-
-      // eslint-disable-next-line consistent-return
-      objectKeys.forEach((key) => {
-        if (['path', 'live'].includes(key)) return false;
-        buttonParameters.push([key, multifunctionButton[key] || defaultButton[key]]);
-      });
-
-      const $multifunctionButton = buildBlock('floating-button', buttonParameters);
-      $multifunctionButton.classList.add('spreadsheet-powered');
-      $main.querySelector(':scope > div:last-of-type').append($multifunctionButton);
-    }
-  }
-}
-
 export async function decorateMain($main) {
   buildAutoBlocks($main);
-  await buildAsyncAutoBlocks($main);
   splitSections($main);
   decorateSections($main);
   decorateButtons($main);


### PR DESCRIPTION
Feat [MWPW-119933](https://jira.corp.adobe.com/browse/MWPW-119933)

Test URLs:

Before:

https://main--express-website--adobe.hlx.page/drafts/qiyundai/auto-multifunction-button
https://main--express-website--adobe.hlx.page/drafts/qiyundai/create/flyer
https://main--express-website--adobe.hlx.page/drafts/qiyundai/auto-floating-button
https://main--express-website--adobe.hlx.page/drafts/qiyundai/auto-overwriting-multifunction-button
https://main--express-website--adobe.hlx.page/express/create/logo
After:

https://mwpw-119933-redo--express-website--webistry-development.hlx.page/drafts/qiyundai/auto-multifunction-button?lighthouse=on
https://mwpw-119933-redo--express-website--webistry-development.hlx.page/drafts/qiyundai/create/flyer?lighthouse=on
https://mwpw-119933-redo--express-website--webistry-development.hlx.page/drafts/qiyundai/auto-floating-button?lighthouse=on
https://mwpw-119933-redo--express-website--webistry-development.hlx.page/drafts/qiyundai/auto-overwriting-multifunction-button?lighthouse=on
https://mwpw-119933-redo--express-website--webistry-development.hlx.page/express/create/logo?lighthouse=on
The five preview links showcase:

A page without any authored floating button nor CTA in column
A page with an existing Multifunction button to be overwritten by spreadsheet powered Multifunction button
A page with an existing Multifunction button to be overwritten by spreadsheet powered floating button
A page with an existing floating button to be overwritten by spreadsheet powered Multifunction button
A live page not affected by the code change because no metadata and dedicated row set in multifunction button sheet

Difference from the original [PR](https://github.com/adobe/express-website/pull/672), this time the block is loaded in as a normal autoBlock but rendered asynchronously in the decorate process