### PR TITLE
Express Homepage ButtonID Analytics

### DIFF
--- a/express/blocks/plans-comparison/plans-comparison.js
+++ b/express/blocks/plans-comparison/plans-comparison.js
@@ -391,6 +391,13 @@ export default function decorate($block) {
         });
 
         fixIcons($newBlock);
+
+        const $blockLinks = $newBlock.querySelectorAll('a');
+
+        if ($blockLinks) {
+          const linksPopulated = new CustomEvent('linkspopulated', { detail: $blockLinks });
+          document.dispatchEvent(linksPopulated);
+        }
       }
     }
   });

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -662,6 +662,28 @@ loadScript(martechURL, () => {
       sparkEventName = 'landing:ctaPressed';
     }
 
+    if (w.location.pathname === '/express/') {
+      if ($a.closest('.hero-animation')) {
+        sparkButtonId = 'getExpressMain';
+      } else if ($a.closest('.make-a-project-item')) {
+        sparkButtonId = 'useCase';
+      } else if ($a.closest('.floating-button')) {
+        sparkButtonId = 'getExpressFloating';
+      } else if ($a.closest('.banner')) {
+        sparkButtonId = 'startForFree';
+      } else if ($a.closest('.columns')) {
+        sparkButtonId = 'browseAllTemplates';
+      } else if ($a.closest('.card-free')) {
+        sparkButtonId = 'getExpressFreePlan';
+      } else if ($a.closest('.card-premium')) {
+        if ($a.classList.contains('primary')) {
+          sparkButtonId = 'getExpressPremiumPlan';
+        } else {
+          sparkButtonId = 'seePlansAndPricing';
+        }
+      }
+    }
+
     if (useAlloy) {
       _satellite.track('event', {
         xdm: {},


### PR DESCRIPTION
Fix https://jira.corp.adobe.com/browse/MWPW-122224

In this Pull Request, I am adding specific button ID tracking to the home page only as requested urgently by the Analytics team. 

Please note that this is only temporary for until we figure out how to generate button ID’s. This code will eventually be removed.

In the future I would suggest that we find a more complete and compatible solution to this as it is not productive to have the development team have to maintain specific button ids (for example, when the homepage changes, I will have to come in and make those changes reflect here, and then there is the question of localisation).

The events have been mapped out by following [this specific document](https://adobe.sharepoint.com/:x:/r/sites/CCXGrowthTeam/Shared%20Documents/Analytics/Experiments/Engagement/AX%20Web%20-%20Logged%20Out%20V2/Express%20Marketing%20Home%20CTA%20Mapping%20Analytics%20Request.xlsx?d=wf3110c8c8a2943ff9f88ec6fb7127e3c&csf=1&web=1&e=lkB8zH) with the exception of SISU tracking.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/
- After: https://mwpw-122224--express-website--webistry-development.hlx.page/express/?lighthouse=on
