### PR TITLE
fix: no buttons for blob store links

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1123,6 +1123,7 @@ export function decorateButtons(block = document) {
     if (!noButtonBlocks.includes(blockName)
       && originalHref !== linkText
       && !(linkText.startsWith('https') && linkText.includes('/media_'))
+      && !linkText.includes('hlx.blob.core.windows.net')
       && !linkText.endsWith(' >')
       && !linkText.endsWith(' ›')) {
       const $up = $a.parentElement;


### PR DESCRIPTION
Media links mistakenly get deocrated as buttons, resulting in a wrong floating CTA.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/tw/express/create/flyer
- After: https://v7-regression--express-website--adobe.hlx.page/tw/express/create/flyer?lighthouse=on
