### PR TITLE
[Quick Action] Fix quickActionType on two analytics events

### DIFF
--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -268,7 +268,7 @@ loadScript(martechURL, () => {
     set('spark.eventData.contextualData2', 'actionLocation:seo');
   }
   if (pathname.includes('/create/video/animation')) {
-    set('spark.eventData.contextualData1', 'quickActionType:createAnimation');
+    set('spark.eventData.contextualData1', 'quickActionType:animateFromAudio');
     set('spark.eventData.contextualData2', 'actionLocation:seo');
   } else if (pathname.includes('/create/video/animation/instagram')) {
     set('spark.eventData.contextualData1', 'quickActionType:createInstagramAnimation');
@@ -307,7 +307,7 @@ loadScript(martechURL, () => {
     set('spark.eventData.contextualData1', 'quickActionType:convertToSVG');
     set('spark.eventData.contextualData2', 'actionLocation:seo');
   } else if (pathname.includes('/feature/video/animate/audio')) {
-    set('spark.eventData.contextualData1', 'quickActionType:animateAudio');
+    set('spark.eventData.contextualData1', 'quickActionType:animateFromAudio');
     set('spark.eventData.contextualData2', 'actionLocation:seo');
   } else if (pathname.includes('/feature/video/trim')) {
     set('spark.eventData.contextualData1', 'quickActionType:trimVideo');

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -267,20 +267,9 @@ loadScript(martechURL, () => {
     set('spark.eventData.contextualData1', `quickActionType:${sparkContextualData}`);
     set('spark.eventData.contextualData2', 'actionLocation:seo');
   }
+
   if (pathname.includes('/create/video/animation')) {
     set('spark.eventData.contextualData1', 'quickActionType:animateFromAudio');
-    set('spark.eventData.contextualData2', 'actionLocation:seo');
-  } else if (pathname.includes('/create/video/animation/instagram')) {
-    set('spark.eventData.contextualData1', 'quickActionType:createInstagramAnimation');
-    set('spark.eventData.contextualData2', 'actionLocation:seo');
-  } else if (pathname.includes('/create/video/animation/social')) {
-    set('spark.eventData.contextualData1', 'quickActionType:createSocialAnimation');
-    set('spark.eventData.contextualData2', 'actionLocation:seo');
-  } else if (pathname.includes('/create/video/animation/tiktok')) {
-    set('spark.eventData.contextualData1', 'quickActionType:createTiktokAnimation');
-    set('spark.eventData.contextualData2', 'actionLocation:seo');
-  } else if (pathname.includes('/create/video/animation/youtube')) {
-    set('spark.eventData.contextualData1', 'quickActionType:createYoutubeAnimation');
     set('spark.eventData.contextualData2', 'actionLocation:seo');
   } else if (pathname.includes('/feature/image/resize')) {
     set('spark.eventData.contextualData1', 'quickActionType:imageResize');


### PR DESCRIPTION
No JIRA ticket was issued as it is a very quick and easy change to make.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/feature/video/animate/audio
- After: https://quick-action-analytics--express-website--webistry-development.hlx.page/express/feature/video/animate/audio?lighthouse=on

- Before: https://main--express-website--adobe.hlx.page/express/create/video/animation
- After: https://quick-action-analytics--express-website--webistry-development.hlx.page/express/create/video/animation?lighthouse=on
