### PR TITLE
fix(templates): allow access to staging default

### DIFF
--- a/express/scripts/templates.js
+++ b/express/scripts/templates.js
@@ -134,5 +134,9 @@ await fetchLinkList();
 if (page) {
   updateBlocks(page);
 } else {
-  window.location.replace('/404');
+  const env = getHelixEnv();
+
+  if ((env && env.name !== 'stage') || window.location.pathname !== '/express/templates/default') {
+    window.location.replace('/404');
+  }
 }


### PR DESCRIPTION
No JIRA ticket provided, this is a fix to allow authors to preview and hopefully update the default templates page without issue.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/templates/default
- After: https://template-default-fix--express-website--webistry-development.hlx.page/express/templates/default?lightouse=on
