### PR TITLE
[MWPW-119277] Fullscreen Marquee fix: Add auto generated floating button

### DIFF
--- a/express/blocks/fullscreen-marquee/fullscreen-marquee.js
+++ b/express/blocks/fullscreen-marquee/fullscreen-marquee.js
@@ -17,6 +17,10 @@ import {
   addFreePlanWidget,
 } from '../../scripts/scripts.js';
 
+import {
+  createFloatingButton,
+} from '../floating-button/floating-button.js';
+
 function styleBackgroundWithScroll($section) {
   const $background = createTag('div', { class: 'marquee-background' });
 
@@ -169,6 +173,8 @@ export default function decorate($block) {
           }
         }
 
+        $a.classList.add('primaryCTA');
+        createFloatingButton($a, $block.closest('.section').dataset.audience);
         styleBackgroundWithScroll($section);
         addFreePlanWidget($block.querySelector('.button-container'));
       }


### PR DESCRIPTION
Add Auto Generated Floating Button(existing feature as in Columns block). No ticket.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/drafts/ernest_sallee/youtube-fullscreen-marquee
- After: https://mwpw-119277-fix--express-website--webistry-development.hlx.page/drafts/ernest_sallee/youtube-fullscreen-marquee?lighthouse=on
