### PR TITLE
fix: large spacing in the How to step carousel block

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -495,7 +495,7 @@ export function decorateSections($main) {
           section.dataset[key] = meta[key];
         }
       });
-      sectionMeta.remove();
+      sectionMeta.parentNode.remove();
     }
 
     if (section.dataset.audience && !noAudienceFound) {


### PR DESCRIPTION
New unexpected large white space in the How to step carousel block

![image](https://user-images.githubusercontent.com/474200/208865356-fd39d739-c1b6-4c28-a678-6c4aac2fbe71.png)

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/create/card
- After: https://fix-howtostep-spacing--express-website--adobe.hlx.page/express/create/card
