### PR TITLE
fix(faq): do not auto-split into its own section

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1666,7 +1666,7 @@ function splitSections($main) {
   const multipleColumns = $main.querySelectorAll('.columns.fullsize-center').length > 1;
   $main.querySelectorAll(':scope > div > div').forEach(($block) => {
     const hasAppStoreBlocks = ['yes', 'true', 'on'].includes(getMetadata('show-standard-app-store-blocks').toLowerCase());
-    const blocksToSplit = ['template-list', 'layouts', 'banner', 'faq', 'promotion', 'fragment', 'app-store-highlight', 'app-store-blade', 'plans-comparison'];
+    const blocksToSplit = ['template-list', 'layouts', 'banner', 'promotion', 'fragment', 'app-store-highlight', 'app-store-blade', 'plans-comparison'];
     // work around for splitting columns and sixcols template list
     // add metadata condition to minimize impact on other use cases
     if (hasAppStoreBlocks && !multipleColumns) {


### PR DESCRIPTION
FAQ blocks can get separated from their headings and appear on top of them.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/create/invoice
- After: https://faq-no-split--express-website--adobe.hlx.page/express/create/invoice?lighthouse=on
