### PR TITLE
fix(spreadsheet MFB): load lottie player for multifunction button explicitly

### DIFF
--- a/express/blocks/floating-button/floating-button.css
+++ b/express/blocks/floating-button/floating-button.css
@@ -213,7 +213,7 @@ main .floating-button-wrapper.multifunction .floating-button .toggle-button .lot
   transition: opacity 0.2s;
 }
 
-main .floating-button-wrapper.multifunction.floating-button--above-the-fold:not(.floating-button--scrolled) .button {
+main .floating-button-wrapper.multifunction .button {
   padding-left: 48px;
 }
 

--- a/express/blocks/floating-button/floating-button.js
+++ b/express/blocks/floating-button/floating-button.js
@@ -409,6 +409,7 @@ function makeCTAFromSheet($block, data) {
 
 export async function createMultiFunctionButton($block, data) {
   if (data.tools.length > 0) {
+    lazyLoadLottiePlayer();
     const $existingFloatingButtons = document.querySelectorAll('.floating-button-wrapper');
     if ($existingFloatingButtons) {
       $existingFloatingButtons.forEach(($button) => {


### PR DESCRIPTION
Fix spreadsheet MFB. No ticket.

During the process of development for spreadsheet based multifunction button, the multifunction portion was split into its own block of function. The missing lottie player wasn't noticed due to the fact that all testing pages had their floating button block to begin with. This is to make sure even a page doesn't have a floating button, a multifunction button will load its own lottie player.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/create/agenda/meeting
- After: https://mwpw-119933-fix--express-website--webistry-development.hlx.page/express/create/agenda/meeting?lighthouse=on
