### PR TITLE
Templates SEO developer testing sheet

### DIFF
--- a/express/scripts/templates.js
+++ b/express/scripts/templates.js
@@ -15,10 +15,11 @@ import {
 } from './scripts.js';
 
 async function fetchPageContent(path) {
+  const env = getHelixEnv();
   const dev = new URLSearchParams(window.location.search).get('dev');
   let sheet;
 
-  if (['yes', 'true', 'on'].includes(dev)) {
+  if (['yes', 'true', 'on'].includes(dev) && env && env.name === 'stage') {
     sheet = '/templates-dev.json?sheet=seo-templates&limit=10000';
   } else {
     sheet = '/express/templates/content.json?sheet=seo-templates&limit=10000';
@@ -31,7 +32,6 @@ async function fetchPageContent(path) {
   }
 
   const page = window.templates.data.find((p) => p.path === path);
-  const env = getHelixEnv();
 
   if (env && env.name === 'stage') {
     return page || null;

--- a/express/scripts/templates.js
+++ b/express/scripts/templates.js
@@ -15,9 +15,18 @@ import {
 } from './scripts.js';
 
 async function fetchPageContent(path) {
+  const dev = new URLSearchParams(window.location.search).get('dev');
+  let sheet;
+
+  if (['yes', 'true', 'on'].includes(dev)) {
+    sheet = '/templates-dev.json?sheet=seo-templates&limit=10000';
+  } else {
+    sheet = '/express/templates/content.json?sheet=seo-templates&limit=10000';
+  }
+
   if (!(window.templates && window.templates.data)) {
     window.templates = {};
-    const resp = await fetch('/express/templates/content.json?sheet=seo-templates&limit=10000');
+    const resp = await fetch(sheet);
     window.templates.data = resp.ok ? (await resp.json()).data : [];
   }
 


### PR DESCRIPTION
There is no JIRA issue provided for this feature request (made by me!)

You can use `?dev=true|on|yes` in order to toggle the dev sheet, and this can only happen in the staging environment.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/templates/flyer/christmas
- After (without dev sheet): https://templates-dev--express-website--webistry-development.hlx.page/express/templates/flyer/christmas?lighthouse=on
- After (with dev sheet): https://templates-dev--express-website--webistry-development.hlx.page/express/templates/flyer/christmas?lighthouse=on&dev=on

You can find the development templates spreadsheet here:
https://adobe.sharepoint.com/:x:/r/sites/CC-Express/Shared%20Documents/website/templates-dev.xlsx?d=w1fb1e30b06ca476997165b2a85a3bf0e&csf=1&web=1&e=Fz6JCa