### PR TITLE
fix(relevant-rows): TOC overlap with Template List title fix take 2

### DIFF
--- a/express/blocks/template-list/template-list.css
+++ b/express/blocks/template-list/template-list.css
@@ -777,6 +777,11 @@ main .template-list-horizontal-fullwidth-mini-container .template-list .template
 }
 
 main .template-list-horizontal-fullwidth-mini-container.toc-container .template-list .template-title {
+  -webkit-hyphens: none; /* safari */
+  hyphens: none;
+}
+
+main .template-list-horizontal-fullwidth-mini-container.toc-container .template-list .template-title::first-line {
   margin-right: 128px;
 }
 

--- a/express/blocks/template-list/template-list.css
+++ b/express/blocks/template-list/template-list.css
@@ -776,13 +776,17 @@ main .template-list-horizontal-fullwidth-mini-container .template-list .template
   margin-bottom: 8px;
 }
 
-main .template-list-horizontal-fullwidth-mini-container.toc-container .template-list .template-title {
+main .template-list-horizontal-fullwidth-mini-container.toc-container .template-list .template-title h2 {
   -webkit-hyphens: none; /* safari */
   hyphens: none;
+  display: inline;
 }
 
-main .template-list-horizontal-fullwidth-mini-container.toc-container .template-list .template-title::first-line {
-  margin-right: 128px;
+main .template-list-horizontal-fullwidth-mini-container.toc-container .template-list .template-title .toc-slot {
+  display: inline;
+  width: 116px;
+  height: 44px;
+  float: right;
 }
 
 main .template-list-horizontal-fullwidth-mini-container .template-list .template-title p:last-of-type {

--- a/express/blocks/template-list/template-list.css
+++ b/express/blocks/template-list/template-list.css
@@ -776,6 +776,10 @@ main .template-list-horizontal-fullwidth-mini-container .template-list .template
   margin-bottom: 8px;
 }
 
+main .template-list-horizontal-fullwidth-mini-container.toc-container .template-list .template-title {
+  margin-right: 128px;
+}
+
 main .template-list-horizontal-fullwidth-mini-container .template-list .template-title p:last-of-type {
   margin-top: 16px;
   font-weight: 800;

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -603,6 +603,7 @@ export async function decorateTemplateList($block) {
         $tocCollidingArea.append($tocSlot, h2);
       }
     }
+    
     if ($block.classList.contains('collaboration')) {
       const $titleHeading = $titleRow.querySelector('h3');
       const $anchorLink = createTag('a', {

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -582,6 +582,7 @@ export async function decorateTemplateList($block) {
   const templates = Array.from($block.children);
   // process single column first row as title
   if (templates[0] && templates[0].children.length === 1) {
+    const $parent = $block.closest('.section');
     const $titleRow = templates.shift();
     $titleRow.classList.add('template-title');
     $titleRow.querySelectorAll(':scope a')
@@ -593,6 +594,15 @@ export async function decorateTemplateList($block) {
         }
       });
 
+    if ($parent.classList.contains('toc-container')) {
+      const $tocCollidingArea = createTag('div', { class: 'toc-colliding-area' });
+      const $tocSlot = createTag('div', { class: 'toc-slot' });
+      const h2 = $titleRow.querySelector('h2');
+      if (h2) {
+        h2.parentElement.prepend($tocCollidingArea);
+        $tocCollidingArea.append($tocSlot, h2);
+      }
+    }
     if ($block.classList.contains('collaboration')) {
       const $titleHeading = $titleRow.querySelector('h3');
       const $anchorLink = createTag('a', {

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -594,7 +594,7 @@ export async function decorateTemplateList($block) {
         }
       });
 
-    if ($parent.classList.contains('toc-container')) {
+    if ($parent && $parent.classList.contains('toc-container')) {
       const $tocCollidingArea = createTag('div', { class: 'toc-colliding-area' });
       const $tocSlot = createTag('div', { class: 'toc-slot' });
       const h2 = $titleRow.querySelector('h2');

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -603,7 +603,7 @@ export async function decorateTemplateList($block) {
         $tocCollidingArea.append($tocSlot, h2);
       }
     }
-    
+
     if ($block.classList.contains('collaboration')) {
       const $titleHeading = $titleRow.querySelector('h3');
       const $anchorLink = createTag('a', {


### PR DESCRIPTION
No ticket.
Remove word-breaks
Adding toc placeholder to make text wrap around TOC.

Test URLs:

Before: https://main--express-website--adobe.hlx.page/express/create/menu
After: https://fix-toc-overlap--express-website--webistry-development.hlx.page/express/create/menu?lighthouse=on