### PR TITLE
fix: word wrap degrade issue

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -2042,6 +2042,7 @@ async function wordBreakJapanese() {
   const { loadDefaultJapaneseParser } = await import('./budoux-index-ja.min.js');
   const parser = loadDefaultJapaneseParser();
   document.querySelectorAll('h1, h2, h3, h4, h5').forEach((el) => {
+    el.classList.add('budoux');
     parser.applyElement(el);
   });
 


### PR DESCRIPTION
Fix word wrap degrade issue. It occurred because the PR https://github.com/adobe/express-website/pull/502 updated budoux-index-ja.min.js.

Add `budoux` class to disable budoux on small screens
https://github.com/adobe/express-website/blob/main/express/styles/styles.css#L966-L976

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/jp/express/
- After: https://fix-word-wrap-degradation--express-website--tamanyan.hlx.page/jp/express/?lighthouse=on

## Related issues

- [fix: disable budoux styles of h1 to h5 on small screens](https://github.com/adobe/express-website/pull/331)

#### Before
<img width="300px" src="https://user-images.githubusercontent.com/2387508/212799669-9f84786d-55c3-4cba-8a63-bf1419564e39.png" />
#### After
<img width="300px" src="https://user-images.githubusercontent.com/2387508/212799683-71c303ea-f6a0-4b30-a6b0-f51636eb2acb.png" />
