### PR TITLE
fix(template-list): search task correction after fetching counts

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -115,6 +115,7 @@ function fetchTemplates(tasks) {
 
 async function appendCategoryTemplatesCount($section) {
   const categories = $section.querySelectorAll('ul.category-list > li');
+  const currentTask = props.filters.tasks;
 
   for (const li of categories) {
     const anchor = li.querySelector('a');
@@ -127,6 +128,8 @@ async function appendCategoryTemplatesCount($section) {
       li.append(countSpan);
     }
   }
+
+  props.filters.tasks = currentTask;
 }
 
 async function processResponse() {


### PR DESCRIPTION
Fix template-list category list -> filter conflict, no ticket.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/templates/search?tasks=flyer&phformat=2:3&topics=flower
- After: https://template-search-hotfix--express-website--webistry-development.hlx.page/express/templates/search?tasks=flyer&phformat=2:3&topics=flower&lighthouse=on