### PR TITLE
fix(duplicate-autoblock): Inject Auto Blocks only to enclosing <main>

### DIFF
--- a/express/blocks/app-store-blade/app-store-blade.js
+++ b/express/blocks/app-store-blade/app-store-blade.js
@@ -211,13 +211,16 @@ export default async function decorate($block) {
     });
 
   if (['yes', 'true', 'on'].includes(getMetadata('show-standard-app-store-blocks').toLowerCase())) {
-    buildStandardPayload($block, payload);
-    const $parentSection = $block.parentNode.parentNode;
-    const $elementToFollow = document.querySelector('.link-list-container');
-    $parentSection.dataset.audience = 'desktop';
+    const enclosingMain = $block.closest('main');
+    if (enclosingMain) {
+      buildStandardPayload($block, payload);
+      const $parentSection = $block.parentNode.parentNode;
+      const $elementToFollow = enclosingMain.querySelector('.link-list-container');
+      $parentSection.dataset.audience = 'desktop';
 
-    if ($elementToFollow) {
-      $elementToFollow.after($parentSection);
+      if ($elementToFollow) {
+        $elementToFollow.after($parentSection);
+      }
     }
   }
 

--- a/express/blocks/app-store-highlight/app-store-highlight.js
+++ b/express/blocks/app-store-highlight/app-store-highlight.js
@@ -11,7 +11,12 @@
  */
 
 import {
-  createOptimizedPicture, createTag, fetchPlaceholders, getIcon, getIconElement, getMetadata,
+  createOptimizedPicture,
+  createTag,
+  fetchPlaceholders,
+  getIcon,
+  getIconElement,
+  getMetadata,
   getMobileOperatingSystem,
 } from '../../scripts/scripts.js';
 

--- a/express/blocks/app-store-highlight/app-store-highlight.js
+++ b/express/blocks/app-store-highlight/app-store-highlight.js
@@ -246,19 +246,22 @@ export default async function decorate($block) {
 
   if (['yes', 'true', 'on'].includes(getMetadata('show-standard-app-store-blocks').toLowerCase())) {
     buildStandardPayload($block, payload);
-    const $parentSection = $block.parentNode.parentNode;
-    const $relevantRows = document.querySelector('.template-list-horizontal-fullwidth-mini-container');
-    let $elementToFollow;
-    if ($relevantRows) {
-      $elementToFollow = $relevantRows;
-    } else {
-      $elementToFollow = document.querySelector('.columns-fullsize-center-container');
-    }
+    const enclosingMain = $block.closest('main');
+    if (enclosingMain) {
+      const $parentSection = $block.parentNode.parentNode;
+      const $relevantRows = enclosingMain.querySelector('.template-list-horizontal-fullwidth-mini-container');
+      let $elementToFollow;
+      if ($relevantRows) {
+        $elementToFollow = $relevantRows;
+      } else {
+        $elementToFollow = enclosingMain.querySelector('.columns-fullsize-center-container');
+      }
 
-    $parentSection.dataset.audience = 'mobile';
+      $parentSection.dataset.audience = 'mobile';
 
-    if ($elementToFollow) {
-      $elementToFollow.after($parentSection);
+      if ($elementToFollow) {
+        $elementToFollow.after($parentSection);
+      }
     }
   }
 

--- a/express/blocks/fragment/fragment.js
+++ b/express/blocks/fragment/fragment.js
@@ -50,7 +50,7 @@ export default async function decorate(block) {
     const fragmentSection = fragment.querySelector(':scope .section');
     if (fragmentSection) {
       block.closest('.section').classList.add(...fragmentSection.classList);
-      block.closest('.fragment-wrapper').replaceWith(...fragmentSection.children);
+      block.closest('.fragment-wrapper').replaceWith(...fragmentSection.childNodes);
     }
   }
 }

--- a/express/blocks/fragment/fragment.js
+++ b/express/blocks/fragment/fragment.js
@@ -18,7 +18,6 @@
  */
 
 import {
-  createTag,
   decorateMain,
   loadBlocks,
 } from '../../scripts/scripts.js';
@@ -32,7 +31,7 @@ async function loadFragment(path) {
   if (path && path.startsWith('/')) {
     const resp = await fetch(`${path}.plain.html`);
     if (resp.ok) {
-      const main = createTag('main', { class: 'fragment' });
+      const main = document.createElement('main');
       main.innerHTML = await resp.text();
       decorateMain(main);
       await loadBlocks(main);

--- a/express/blocks/fragment/fragment.js
+++ b/express/blocks/fragment/fragment.js
@@ -18,6 +18,7 @@
  */
 
 import {
+  createTag,
   decorateMain,
   loadBlocks,
 } from '../../scripts/scripts.js';
@@ -31,7 +32,7 @@ async function loadFragment(path) {
   if (path && path.startsWith('/')) {
     const resp = await fetch(`${path}.plain.html`);
     if (resp.ok) {
-      const main = document.createElement('main');
+      const main = createTag('main', { class: 'fragment' });
       main.innerHTML = await resp.text();
       decorateMain(main);
       await loadBlocks(main);

--- a/express/blocks/plans-comparison/plans-comparison.css
+++ b/express/blocks/plans-comparison/plans-comparison.css
@@ -4,6 +4,10 @@ main .plans-comparison-container {
     max-width: calc(100% - 40px);
 }
 
+main .plans-comparison-container .plans-comparison-wrapper {
+    max-width: none;
+}
+
 main .plans-comparison-container .plans-comparison {
     margin: 0;
 }

--- a/express/blocks/plans-comparison/plans-comparison.js
+++ b/express/blocks/plans-comparison/plans-comparison.js
@@ -11,7 +11,7 @@
  */
 
 import {
-  createTag, fixIcons, getIconElement, getLocale, getOffer, loadBlocks,
+  createTag, fixIcons, getIconElement, getLocale, getOffer,
 } from '../../scripts/scripts.js';
 
 async function decorateAsFragment($block, content) {

--- a/express/blocks/plans-comparison/plans-comparison.js
+++ b/express/blocks/plans-comparison/plans-comparison.js
@@ -29,8 +29,6 @@ async function decorateAsFragment($block, content) {
     if (img) {
       img.setAttribute('loading', 'lazy');
     }
-    const loadedBlocks = await loadBlocks($newBlock);
-    await Promise.all(loadedBlocks);
     const $section = $block.closest('.section');
     $section.parentNode.replaceChild($newBlock, $section);
     document.dispatchEvent(new Event('planscomparisonloaded'));
@@ -232,7 +230,7 @@ function decorateToggleButton($block, $card, payload) {
 
 function decorateFeatures($block, payload, value) {
   const $featuresWrapper = createTag('ul', { class: 'features-wrapper' });
-  if (value) {
+  if (value && value.features) {
     value.features.forEach((feature) => {
       $featuresWrapper.append(feature);
     });
@@ -242,16 +240,18 @@ function decorateFeatures($block, payload, value) {
 
 function decorateCTAs($block, payload, value) {
   const $buttonsWrapper = createTag('ul', { class: 'ctas-wrapper' });
-  value.ctas.forEach((cta, index) => {
-    $buttonsWrapper.append(cta);
-    if (index === 0) {
-      cta.classList.add('primary');
-    }
+  if (value && value.ctas) {
+    value.ctas.forEach((cta, index) => {
+      $buttonsWrapper.append(cta);
+      if (index === 0) {
+        cta.classList.add('primary');
+      }
 
-    cta.addEventListener('click', (e) => {
-      e.stopPropagation();
+      cta.addEventListener('click', (e) => {
+        e.stopPropagation();
+      });
     });
-  });
+  }
 
   return $buttonsWrapper;
 }

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -16,7 +16,6 @@ import {
   addFreePlanWidget,
   addSearchQueryToHref,
   createTag,
-  decorateMain,
   fetchPlaceholders,
   getIconElement,
   getLocale,
@@ -249,7 +248,6 @@ async function fetchBlueprint(pathname) {
   const body = await resp.text();
   const $main = createTag('main');
   $main.innerHTML = body;
-  await decorateMain($main);
 
   window.spark.$blueprint = $main;
   return ($main);

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -16,6 +16,7 @@ import {
   addFreePlanWidget,
   addSearchQueryToHref,
   createTag,
+  decorateMain,
   fetchPlaceholders,
   getIconElement,
   getLocale,
@@ -248,6 +249,7 @@ async function fetchBlueprint(pathname) {
   const body = await resp.text();
   const $main = createTag('main');
   $main.innerHTML = body;
+  await decorateMain($main);
 
   window.spark.$blueprint = $main;
   return ($main);

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -957,7 +957,6 @@ export function buildBlock(blockName, content) {
  * @param {Element} block The block element
  */
 export async function loadBlock(block, eager = false) {
-  // console.log(`block: ${block.className}, main: ${document.querySelector('main').cloneNode(true).className}`);
   if (!(block.getAttribute('data-block-status') === 'loading' || block.getAttribute('data-block-status') === 'loaded')) {
     block.setAttribute('data-block-status', 'loading');
     const blockName = block.getAttribute('data-block-name');
@@ -1012,11 +1011,6 @@ export async function loadBlock(block, eager = false) {
 export async function loadBlocks(main) {
   updateSectionsStatus(main);
   const blocks = [...main.querySelectorAll('div.block')];
-  blocks.forEach((b) => {
-    if (main.className) {
-      b.classList.add(`from-${main.className}`)
-    }
-  });
   for (let i = 0; i < blocks.length; i += 1) {
     // eslint-disable-next-line no-await-in-loop
     await loadBlock(blocks[i]);

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1638,50 +1638,49 @@ export async function fetchPlainBlockFromFragment($block, url, blockName) {
 }
 
 function buildAutoBlocks($main) {
-  const $lastDiv = $main.querySelector(':scope > div:last-of-type');
+  if (!$main.classList.contains('fragment')) {
+    const $lastDiv = $main.querySelector(':scope > div:last-of-type');
 
-  // Load the branch.io banner autoblock...
-  if (['yes', 'true', 'on'].includes(getMetadata('show-banner').toLowerCase())) {
-    const branchio = buildBlock('branch-io', '');
-    if ($lastDiv) {
-      $lastDiv.append(branchio);
+    // Load the branch.io banner autoblock...
+    if (['yes', 'true', 'on'].includes(getMetadata('show-banner').toLowerCase())) {
+      const branchio = buildBlock('branch-io', '');
+      if ($lastDiv) {
+        $lastDiv.append(branchio);
+      }
     }
-  }
 
-  // Load the app store autoblocks...
-  if (['yes', 'true', 'on'].includes(getMetadata('show-standard-app-store-blocks').toLowerCase())) {
-    if ($main.querySelector('.app-store-highlight') === null) {
+    // Load the app store autoblocks...
+    if (['yes', 'true', 'on'].includes(getMetadata('show-standard-app-store-blocks').toLowerCase())) {
       const $highlight = buildBlock('app-store-highlight', '');
       if ($lastDiv) {
         $lastDiv.append($highlight);
       }
-    }
-    if ($main.querySelector('.app-store-blade') === null) {
+
       const $blade = buildBlock('app-store-blade', '');
       if ($lastDiv) {
         $lastDiv.append($blade);
       }
     }
-  }
 
-  if (['yes', 'true', 'on'].includes(getMetadata('show-plans-comparison').toLowerCase())) {
-    const $plansComparison = buildBlock('plans-comparison', '');
-    if ($lastDiv) {
-      $lastDiv.append($plansComparison);
+    if (['yes', 'true', 'on'].includes(getMetadata('show-plans-comparison').toLowerCase())) {
+      const $plansComparison = buildBlock('plans-comparison', '');
+      if ($lastDiv) {
+        $lastDiv.append($plansComparison);
+      }
     }
-  }
 
-  if (['yes', 'true', 'on'].includes(getMetadata('show-multifunction-button').toLowerCase())) {
-    const $multifunctionButton = buildBlock('floating-button', '');
-    $multifunctionButton.classList.add('spreadsheet-powered');
-    $main.querySelector(':scope > div:last-of-type').append($multifunctionButton);
-  }
+    if (['yes', 'true', 'on'].includes(getMetadata('show-multifunction-button').toLowerCase())) {
+      const $multifunctionButton = buildBlock('floating-button', '');
+      $multifunctionButton.classList.add('spreadsheet-powered');
+      $main.querySelector(':scope > div:last-of-type').append($multifunctionButton);
+    }
 
-  if (getMetadata('show-quick-action-card') && !['no', 'false', 'off'].includes(getMetadata('show-multifunction-button').toLowerCase())) {
-    const fragmentName = getMetadata('show-quick-action-card').toLowerCase();
-    const quickActionCardBlock = buildBlock('quick-action-card', fragmentName);
-    quickActionCardBlock.classList.add('spreadsheet-powered');
-    $main.querySelector(':scope > div:last-of-type').append(quickActionCardBlock);
+    if (getMetadata('show-quick-action-card') && !['no', 'false', 'off'].includes(getMetadata('show-multifunction-button').toLowerCase())) {
+      const fragmentName = getMetadata('show-quick-action-card').toLowerCase();
+      const quickActionCardBlock = buildBlock('quick-action-card', fragmentName);
+      quickActionCardBlock.classList.add('spreadsheet-powered');
+      $main.querySelector(':scope > div:last-of-type').append(quickActionCardBlock);
+    }
   }
 }
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -957,6 +957,7 @@ export function buildBlock(blockName, content) {
  * @param {Element} block The block element
  */
 export async function loadBlock(block, eager = false) {
+  // console.log(`block: ${block.className}, main: ${document.querySelector('main').cloneNode(true).className}`);
   if (!(block.getAttribute('data-block-status') === 'loading' || block.getAttribute('data-block-status') === 'loaded')) {
     block.setAttribute('data-block-status', 'loading');
     const blockName = block.getAttribute('data-block-name');
@@ -1011,6 +1012,11 @@ export async function loadBlock(block, eager = false) {
 export async function loadBlocks(main) {
   updateSectionsStatus(main);
   const blocks = [...main.querySelectorAll('div.block')];
+  blocks.forEach((b) => {
+    if (main.className) {
+      b.classList.add(`from-${main.className}`)
+    }
+  });
   for (let i = 0; i < blocks.length; i += 1) {
     // eslint-disable-next-line no-await-in-loop
     await loadBlock(blocks[i]);
@@ -1638,7 +1644,10 @@ export async function fetchPlainBlockFromFragment($block, url, blockName) {
 }
 
 function buildAutoBlocks($main) {
-  if (!$main.classList.contains('fragment')) {
+  console.log('loadAutoBlocks running')
+  console.log(`className we get accessing directly from $main: ${$main.className}`);
+  console.log(`className we get when querySelect main from document: ${document.querySelector('main').className}`);
+  // if (!$main.classList.contains('fragment')) {
     const $lastDiv = $main.querySelector(':scope > div:last-of-type');
 
     // Load the branch.io banner autoblock...
@@ -1672,16 +1681,16 @@ function buildAutoBlocks($main) {
     if (['yes', 'true', 'on'].includes(getMetadata('show-multifunction-button').toLowerCase())) {
       const $multifunctionButton = buildBlock('floating-button', '');
       $multifunctionButton.classList.add('spreadsheet-powered');
-      $main.querySelector(':scope > div:last-of-type').append($multifunctionButton);
+      $lastDiv.append($multifunctionButton);
     }
 
     if (getMetadata('show-quick-action-card') && !['no', 'false', 'off'].includes(getMetadata('show-multifunction-button').toLowerCase())) {
       const fragmentName = getMetadata('show-quick-action-card').toLowerCase();
       const quickActionCardBlock = buildBlock('quick-action-card', fragmentName);
       quickActionCardBlock.classList.add('spreadsheet-powered');
-      $main.querySelector(':scope > div:last-of-type').append(quickActionCardBlock);
+      $lastDiv.append(quickActionCardBlock);
     }
-  }
+  // }
 }
 
 function splitSections($main) {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1644,53 +1644,52 @@ export async function fetchPlainBlockFromFragment($block, url, blockName) {
 }
 
 function buildAutoBlocks($main) {
-  console.log('loadAutoBlocks running')
-  console.log(`className we get accessing directly from $main: ${$main.className}`);
-  console.log(`className we get when querySelect main from document: ${document.querySelector('main').className}`);
-  // if (!$main.classList.contains('fragment')) {
-    const $lastDiv = $main.querySelector(':scope > div:last-of-type');
+  const $lastDiv = $main.querySelector(':scope > div:last-of-type');
 
-    // Load the branch.io banner autoblock...
-    if (['yes', 'true', 'on'].includes(getMetadata('show-banner').toLowerCase())) {
-      const branchio = buildBlock('branch-io', '');
-      if ($lastDiv) {
-        $lastDiv.append(branchio);
-      }
+  // Load the branch.io banner autoblock...
+  if (['yes', 'true', 'on'].includes(getMetadata('show-banner').toLowerCase())) {
+    const branchio = buildBlock('branch-io', '');
+    if ($lastDiv) {
+      $lastDiv.append(branchio);
+    }
+  }
+
+  // Load the app store autoblocks...
+  if (['yes', 'true', 'on'].includes(getMetadata('show-standard-app-store-blocks').toLowerCase())) {
+    const $highlight = buildBlock('app-store-highlight', '');
+    if ($lastDiv) {
+      $lastDiv.append($highlight);
     }
 
-    // Load the app store autoblocks...
-    if (['yes', 'true', 'on'].includes(getMetadata('show-standard-app-store-blocks').toLowerCase())) {
-      const $highlight = buildBlock('app-store-highlight', '');
-      if ($lastDiv) {
-        $lastDiv.append($highlight);
-      }
-
-      const $blade = buildBlock('app-store-blade', '');
-      if ($lastDiv) {
-        $lastDiv.append($blade);
-      }
+    const $blade = buildBlock('app-store-blade', '');
+    if ($lastDiv) {
+      $lastDiv.append($blade);
     }
+  }
 
-    if (['yes', 'true', 'on'].includes(getMetadata('show-plans-comparison').toLowerCase())) {
-      const $plansComparison = buildBlock('plans-comparison', '');
-      if ($lastDiv) {
-        $lastDiv.append($plansComparison);
-      }
+  if (['yes', 'true', 'on'].includes(getMetadata('show-plans-comparison').toLowerCase())) {
+    const $plansComparison = buildBlock('plans-comparison', '');
+    if ($lastDiv) {
+      $lastDiv.append($plansComparison);
     }
+  }
 
-    if (['yes', 'true', 'on'].includes(getMetadata('show-multifunction-button').toLowerCase())) {
-      const $multifunctionButton = buildBlock('floating-button', '');
-      $multifunctionButton.classList.add('spreadsheet-powered');
+  if (['yes', 'true', 'on'].includes(getMetadata('show-multifunction-button').toLowerCase())) {
+    const $multifunctionButton = buildBlock('floating-button', '');
+    $multifunctionButton.classList.add('spreadsheet-powered');
+    if ($lastDiv) {
       $lastDiv.append($multifunctionButton);
     }
+  }
 
-    if (getMetadata('show-quick-action-card') && !['no', 'false', 'off'].includes(getMetadata('show-multifunction-button').toLowerCase())) {
-      const fragmentName = getMetadata('show-quick-action-card').toLowerCase();
-      const quickActionCardBlock = buildBlock('quick-action-card', fragmentName);
-      quickActionCardBlock.classList.add('spreadsheet-powered');
+  if (getMetadata('show-quick-action-card') && !['no', 'false', 'off'].includes(getMetadata('show-multifunction-button').toLowerCase())) {
+    const fragmentName = getMetadata('show-quick-action-card').toLowerCase();
+    const quickActionCardBlock = buildBlock('quick-action-card', fragmentName);
+    quickActionCardBlock.classList.add('spreadsheet-powered');
+    if ($lastDiv) {
       $lastDiv.append(quickActionCardBlock);
     }
-  // }
+  }
 }
 
 function splitSections($main) {


### PR DESCRIPTION
Proactive Fix PR: Since we started using auto generated blocks, the decorateMain() function call inside fragment blocks have been trying to render auto blocks for as many extra times as the amount of fragments being used on the page. Loading plain html doesn't stop the auto blocks from loading as the fragment main is loaded on the same URL, which triggers the metadata powered auto blocks.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/create/card
- After: https://duplicate-app-block--express-website--webistry-development.hlx.page/express/create/card?lighthouse=on
