### PR TITLE
fix(icon-list): pre-processed icons garbled

### DIFF
--- a/express/blocks/icon-list/icon-list.js
+++ b/express/blocks/icon-list/icon-list.js
@@ -28,7 +28,7 @@ export default function decorate($block) {
     /* legacy icon list */
     addBlockClasses($block, ['icon-list-image', 'icon-list-description']);
     $block.querySelectorAll(':scope>div').forEach(($row) => {
-      if ($row.children && $row.children[1]) {
+      if ($row.children && $row.children[1] && !$row.querySelector('img, svg')) {
         const iconName = toClassName($row.children[0].textContent.trim());
         if (iconName && !iconName.startsWith('-')) {
           $row.children[0].innerHTML = iconName ? getIcon(iconName) : '';


### PR DESCRIPTION
Pre-priocessed icons get replaced again and potentially broken.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/nonprofits
- After: https://icon-list-bug--express-website--adobe.hlx.page/express/nonprofits?lighthouse=on
