### PR TITLE
[MWPW-123031] Button ID analytics emergency hotfix

### DIFF
--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -696,14 +696,6 @@ loadScript(martechURL, () => {
       sparkButtonId = `${sparkButtonId}${textToName($a.innerText.trim())} ${index}`;
     }
 
-    if ($a.href.includes('/express/')) {
-      sparkEventDestination = 'internalLink';
-    } else if ($a.href.includes('adobesparkpost.app.link')) {
-      sparkEventDestination = 'product';
-    } else {
-      sparkEventDestination = 'externalLink';
-    }
-
     if (useAlloy) {
       _satellite.track('event', {
         xdm: {},

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -519,7 +519,6 @@ loadScript(martechURL, () => {
     let adobeEventName = 'adobe.com:express:cta:';
     let sparkEventName;
     let sparkButtonId;
-    let sparkEventDestination;
 
     const $templateContainer = $a.closest('.template-list');
     const $tutorialContainer = $a.closest('.tutorial-card');

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -730,7 +730,6 @@ loadScript(martechURL, () => {
                   eventName: sparkEventName,
                   trigger: sparkTouchpoint,
                   buttonId: sparkButtonId || '',
-                  contextualData1: sparkEventDestination || '',
                   sendTimestamp: new Date().getTime(),
                 },
               },


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://jira.corp.adobe.com/browse/MWPW-123031

Test URLs:
Before: https://main--express-website--adobe.hlx.page/express/create/poster
After: https://mwpw-123031--express-website--webistry-development.hlx.page/express/create/poster?lighthouse=on

This is an emergency hotfix to rollback the overide on contextualData1.
