### PR TITLE
[MWPW-123315] Quick Action Cards - Hyphens on carousel text

### DIFF
--- a/express/blocks/quick-action-card/quick-action-card.css
+++ b/express/blocks/quick-action-card/quick-action-card.css
@@ -158,6 +158,7 @@ main .quick-action-card .carousel-platform span {
   font-size: 16px;
   text-align: center;
   max-width: 66px;
+  hyphens: auto;
 }
 
 main .quick-action-card .carousel-container::before {


### PR DESCRIPTION
Fix https://jira.corp.adobe.com/browse/MWPW-123315

Test URLs:

- Before: https://main--express-website--webistry-development.hlx.page/drafts/casey/quick-action-card/resize
- After: https://mwpw-123315-2--express-website--webistry-development.hlx.page/drafts/casey/quick-action-card/resize?lighthouse=on

Added auto-hyphenation to the text on the carousel to avoid the overflow that was occurring in some languages.