### PR TITLE
feat: adding content square tracking vars to franklin experiments

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1551,6 +1551,15 @@ async function decorateTesting() {
           }
           sampleRUM('experiment', { source: config.id, target: config.selectedVariant });
           console.log(`running experiment (${window.hlx.experiment.id}) -> ${window.hlx.experiment.selectedVariant}`);
+          // populate ttMETA with hlx experimentation details
+          window.ttMETA = window.ttMETA || [];
+          const experimentDetails = {
+            CampaignId: window.hlx.experiment.id,
+            CampaignName: window.hlx.experiment.experimentName,
+            OfferId: window.hlx.experiment.selectedVariant,
+            OfferName: window.hlx.experiment.variants[window.hlx.experiment.selectedVariant].label,
+          };
+          window.ttMETA.push(experimentDetails);
           if (config.selectedVariant !== 'control') {
             const currentPath = window.location.pathname;
             const pageIndex = config.variants.control.pages.indexOf(currentPath);

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1535,7 +1535,7 @@ async function decorateTesting() {
       console.log('experiment', experiment);
       const config = await getExperimentConfig(experiment);
       if (!config) {
-        console.error("config is null");
+        console.error('config is null');
         return;
       }
       console.log(config);

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1534,6 +1534,10 @@ async function decorateTesting() {
     if (experiment) {
       console.log('experiment', experiment);
       const config = await getExperimentConfig(experiment);
+      if (!config) {
+        console.error("config is null");
+        return;
+      }
       console.log(config);
       if (toCamelCase(config.status) === 'active' || forcedExperiment) {
         config.run = forcedExperiment || checkExperimentAudience(toClassName(config.audience));


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

When Contentsquare is loaded through Adobe Launch, Contentsquare looks at the ttMETA object. Populating the `ttMETA` object with Franklin experiment details.

Fixes - [SITES-11885](https://jira.corp.adobe.com/browse/SITES-11885)

Test URLs:
https://contentsqaure-integration--express-website--adobe.hlx.live/express/

I couldn't find a page where Franklin experiment is running now, so just used the /express/, please let me know if there's a page, then I can update the Test Urls.