### PR TITLE
feat: Contentsqaure integration on stage

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1368,6 +1368,15 @@ async function decorateTesting() {
           setLastExperimentVariant(config.id, config.selectedVariant);
           sampleRUM('experiment', { source: config.id, target: config.selectedVariant });
           console.log(`running experiment (${window.hlx.experiment.id}) -> ${window.hlx.experiment.selectedVariant}`);
+          // populate ttMETA with hlx experimentation details
+          window.ttMETA = window.ttMETA || [];
+          const experimentDetails = {
+            CampaignId: window.hlx.experiment.id,
+            CampaignName: window.hlx.experiment.experimentName,
+            OfferId: window.hlx.experiment.selectedVariant,
+            OfferName: window.hlx.experiment.variants[window.hlx.experiment.selectedVariant].label,
+          };
+          window.ttMETA.push(experimentDetails);
           if (config.selectedVariant !== 'control') {
             const currentPath = window.location.pathname;
             const pageIndex = config.variants.control.pages.indexOf(currentPath);


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

When Contentsquare is loaded through Adobe Launch, Contentsquare looks at the ttMETA object. Populating the ttMETA object with Franklin experiment details. This is to validate Contentsquare integration on stage environment

Fixes - [SITES-11885](https://jira.corp.adobe.com/browse/SITES-11885)

Test URLs:
https://contentsqaure-integration-stage--express-website--adobe.hlx.page/express/