### PR TITLE
fix(quick-action-card): hyphen on safari

### DIFF
--- a/express/blocks/quick-action-card/quick-action-card.css
+++ b/express/blocks/quick-action-card/quick-action-card.css
@@ -158,8 +158,11 @@ main .quick-action-card .carousel-platform span {
   font-size: 16px;
   text-align: center;
   max-width: 66px;
-  hyphens: auto;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
   -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  hyphens: auto;
 }
 
 main .quick-action-card .carousel-container::before {

--- a/express/blocks/quick-action-card/quick-action-card.css
+++ b/express/blocks/quick-action-card/quick-action-card.css
@@ -153,15 +153,11 @@ main .quick-action-card .carousel-platform svg {
 }
 
 main .quick-action-card .carousel-platform span {
-  display: flex;
-  justify-content: center;
+  display: block;
   font-size: 16px;
   text-align: center;
   max-width: 66px;
-  word-wrap: break-word;
-  overflow-wrap: break-word;
   -webkit-hyphens: auto;
-  -moz-hyphens: auto;
   hyphens: auto;
 }
 

--- a/express/blocks/quick-action-card/quick-action-card.css
+++ b/express/blocks/quick-action-card/quick-action-card.css
@@ -159,6 +159,7 @@ main .quick-action-card .carousel-platform span {
   text-align: center;
   max-width: 66px;
   hyphens: auto;
+  -webkit-hyphens: auto;
 }
 
 main .quick-action-card .carousel-container::before {


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

No ticket.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/nl/express/fragments/quick-action-card/generic
- After: https://hyphen-safari-fix--express-website--webistry-development.hlx.page/nl/express/fragments/quick-action-card/generic
