### PR TITLE
[MWPW 122517] Breadcrumbs

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -154,6 +154,9 @@ function loadFEDS() {
 
   const breadCrumbList = [];
   async function buildBreadCrumbArray() {
+    if (isHomepage) {
+      return
+    }
     const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
     const buildBreadCrumb = (path, name, parentPath = '') => (
       { title: capitalize(name), url: `${parentPath}/${path}` }
@@ -170,7 +173,9 @@ function loadFEDS() {
     const pagesShortNameElement = document.querySelector('meta[name="short-title"]');
     const pagesShortName = pagesShortNameElement ? pagesShortNameElement.getAttribute('content') : null;
 
-    if (isHomepage || (!pagesShortName && pathSegments.length > 2)) {
+    if (getMetadata('hide-breadcrumbs') === 'true'
+    || (!pagesShortName && pathSegments.length > 2)
+    || locale !== 'us') { // Remove this line once locale translations are complete
       return;
     }
     if (placeholders[category]) {
@@ -202,9 +207,7 @@ function loadFEDS() {
     },
     locale: (locale === 'us' ? 'en' : locale),
     content: {
-      experience: 'adobe-express/ax-gnav-homepage',
-      // experience: "adobe-express/ax-gnav"
-      // experience: getMetadata('gnav') || fedsExp,
+      experience: getMetadata('gnav') || fedsExp,
     },
     profile: {
       customSignIn: () => {

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -155,7 +155,7 @@ function loadFEDS() {
   const breadCrumbList = [];
   async function buildBreadCrumbArray() {
     if (isHomepage) {
-      return
+      return;
     }
     const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
     const buildBreadCrumb = (path, name, parentPath = '') => (
@@ -168,20 +168,19 @@ function loadFEDS() {
       .filter((element) => element !== '')
       .filter((element) => element !== locale);
     const localePath = locale === 'us' ? '' : `${locale}/`;
-    let category = pathSegments[1].toLowerCase();
-    const secondPathSegment = category;
+    let category = pathSegments[1];
+    const secondPathSegment = category.toLowerCase();
     const pagesShortNameElement = document.querySelector('meta[name="short-title"]');
     const pagesShortName = pagesShortNameElement ? pagesShortNameElement.getAttribute('content') : null;
 
     if (getMetadata('hide-breadcrumbs') === 'true'
     || (!pagesShortName && pathSegments.length > 2)
+    || !placeholders[`breadcrumbs-${category}`]
     || locale !== 'us') { // Remove this line once locale translations are complete
       return;
     }
-    if (placeholders[category]) {
-      category = capitalize(placeholders[category]);
-      validCategories.push(category);
-    }
+    category = capitalize(placeholders[`breadcrumbs-${category}`]);
+    validCategories.push(category);
 
     const secondBreadCrumb = buildBreadCrumb(secondPathSegment, category, `${localePath}/express`);
     breadCrumbList.push(secondBreadCrumb);

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -151,6 +151,17 @@ function loadFEDS() {
     ? `adobe-express/ax-gnav${isHomepage ? '-homepage' : ''}`
     : 'cc-express/cc-express-gnav';
 
+  const currentURL = new URL(window.location);
+  const origin = currentURL.origin
+  const linkList = currentURL.pathname.split('/');
+  linkList.shift();
+  const breadcrumbList = [];
+  let buildPath = `${origin}/`;
+  linkList.forEach((pathName) => {
+    buildPath += `${pathName}/`;
+    breadcrumbList.push({ title: pathName, url: buildPath });
+  });
+
   window.fedsConfig = {
     ...(window.fedsConfig || {}),
 
@@ -185,6 +196,10 @@ function loadFEDS() {
         surfaceVersion: '1',
       }
       : {},
+    breadcrumbs: {
+      showLogo: true,
+      links: breadcrumbList,
+    },
   };
 
   window.addEventListener('feds.events.experience.loaded', async () => {

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -146,25 +146,53 @@ function loadFEDS() {
 
   const isHomepage = window.location.pathname.endsWith('/express/');
   const isMegaNav = window.location.pathname.startsWith('/express')
-    || window.location.pathname.startsWith('/education');
+  || window.location.pathname.startsWith('/education');
   const fedsExp = isMegaNav
     ? `adobe-express/ax-gnav${isHomepage ? '-homepage' : ''}`
     : 'cc-express/cc-express-gnav';
 
-  const breadCrumbList = [{ title: 'Homepage', url: 'https://www.adobe.com/express' }];
-  const category = window.location.pathname.split('/')[2];
-  const categoryCapitalized = category.charAt(0).toUpperCase() + category.slice(1);
-  const secondBreadcrumb = { title: categoryCapitalized, url: `https://www.adobe.com/express/${category}` };
-  if (['create', 'feature', 'template'].includes(category.toLowerCase())) {
-    const thirdBreadcrumbName = document.querySelector('meta[name="short-title"]').getAttribute('content') || '';
-    const thirdBreadcrumb = { title: thirdBreadcrumbName, url: `${secondBreadcrumb.url}/${thirdBreadcrumbName}` };
-    breadCrumbList.push(secondBreadcrumb, thirdBreadcrumb);
+  function buildBreadCrumbs() {
+    if (isHomepage) {
+      return;
+    }
+    const breadCrumbList = [];
+    const validCategories = ['create', 'feature', 'templates'];
+    let pathList = window.location.pathname.split('/');
+    pathList = pathList.filter((element) => element !== '');
+    const category = pathList[1].toLowerCase();
+    const categoryCapitalized = category.charAt(0).toUpperCase() + category.slice(1);
+    const firstBreadcrumb = { title: 'Homepage', url: 'https://www.adobe.com/express' };
+    // If the get metadata returns a value, use that instead of the second breadcrumb
+    const secondBreadcrumb = { title: categoryCapitalized, url: `https://www.adobe.com/express/${category}` };
+    let pagesShortName;
+    if (document.querySelector('meta[name="short-title"]')) {
+      pagesShortName = document.querySelector('meta[name="short-title"]').getAttribute('content') || '';
+    }
+    const thirdBreadcrumb = { title: pagesShortName, url: `${secondBreadcrumb.url}/${pagesShortName}` };
+
+    switch (pathList.length) {
+      case 2:
+        breadCrumbList.push(firstBreadcrumb);
+        if (validCategories.includes(category)) {
+          breadCrumbList.push(secondBreadcrumb);
+        }
+        break;
+      case 3:
+        if (pagesShortName) {
+          if (validCategories.includes(category)) {
+            breadCrumbList.push(firstBreadcrumb, secondBreadcrumb, thirdBreadcrumb);
+          } else {
+            breadCrumbList.push(firstBreadcrumb);
+          }
+        }
+        break;
+      default:
+        return;
+    }
+    return breadCrumbList;
   }
 
-  const test = document.querySelector('header')
-  const subnav = createTag('div', { id: 'feds-subnav' });
-  test.append(subnav);
-
+  const breadCrumbList = buildBreadCrumbs();
   window.fedsConfig = {
     ...(window.fedsConfig || {}),
 

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -153,8 +153,9 @@ function loadFEDS() {
     : 'cc-express/cc-express-gnav';
 
   const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
-  function buildBreadCrumb(parentURL, path, name) {
-    return { title: capitalize(name), url: `${parentURL}/${path}` };
+
+  function buildBreadCrumb(path, name, parentPath = '') {
+    return { title: capitalize(name), url: `${parentPath}/${path}` };
   }
 
   const breadCrumbList = [];
@@ -163,11 +164,17 @@ function loadFEDS() {
     const validCategories = ['create', 'feature', 'templates'];
     let pathList = window.location.pathname.split('/');
     pathList = pathList.filter((element) => element !== '');
-    const firstBreadCrumb = buildBreadCrumb('adobe.com', 'express', 'Homepage');
+    pathList = pathList.filter((element) => element !== locale);
+    const localePath = locale !== 'us' ? `${locale}/` : '';
+    const firstBreadCrumb = buildBreadCrumb(`${localePath}express/`, 'Homepage');
     let category = pathList[1].toLowerCase();
     const categoryURL = category;
 
-    if (isHomepage || !validCategories.includes(pathList[1])) {
+    if (isHomepage) {
+      return;
+    }
+    if (!validCategories.includes(pathList[1])) {
+      breadCrumbList.push(firstBreadCrumb);
       return;
     }
     if (placeholders[category]) {
@@ -175,7 +182,7 @@ function loadFEDS() {
       validCategories.push(category);
     }
 
-    const secondBreadCrumb = buildBreadCrumb(firstBreadCrumb.url, categoryURL, category);
+    const secondBreadCrumb = buildBreadCrumb(categoryURL, category, `/${locale}/express`);
     let pagesShortName;
     if (document.querySelector('meta[name="short-title"]') && pathList.length === 3) {
       pagesShortName = document.querySelector('meta[name="short-title"]').getAttribute('content') || '';
@@ -186,43 +193,24 @@ function loadFEDS() {
 
     let thirdBreadCrumb;
     if (pathList.length === 3) {
-      thirdBreadCrumb = buildBreadCrumb(secondBreadCrumb.url, pagesShortName, pagesShortName);
+      thirdBreadCrumb = buildBreadCrumb(pagesShortName, pagesShortName, secondBreadCrumb.url);
     } else if (pathList.length > 3) {
-      thirdBreadCrumb = buildBreadCrumb(secondBreadCrumb.url, pathList[2], pathList[2]);
+      thirdBreadCrumb = buildBreadCrumb(pathList[2], pathList[2], secondBreadCrumb.url);
     }
 
     breadCrumbList.push(firstBreadCrumb);
     if (validCategories.includes(category)) {
       breadCrumbList.push(secondBreadCrumb);
     }
-    if (pathList.length === 3) {
+    if (pathList.length >= 3) {
       breadCrumbList.push(thirdBreadCrumb);
     }
 
     let runningURL = secondBreadCrumb.url;
     for (let i = breadCrumbList.length; i < pathList.length; i += 1) {
-      breadCrumbList.push(buildBreadCrumb(runningURL, pathList[i], pathList[i]));
+      breadCrumbList.push(buildBreadCrumb(pathList[i], pathList[i], runningURL));
       runningURL = `${runningURL}/${pathList[i]}`;
     }
-
-    // switch (pathList.length) {
-    //   case 2:
-    //     breadCrumbList.push(firstBreadcrumb);
-    //     if (validCategories.includes(category)) {
-    //       breadCrumbList.push(secondBreadcrumb);
-    //     }
-    //     break;
-    //   case 3:
-    //     if (pagesShortName) {
-    //       if (validCategories.includes(category)) {
-    //         breadCrumbList.push(firstBreadcrumb, secondBreadcrumb, thirdBreadcrumb);
-    //       } else {
-    //         breadCrumbList.push(firstBreadcrumb);
-    //       }
-    //     }
-    //   break;
-    // default:
-    // }
   }
 
   buildBreadCrumbArray();

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -151,16 +151,19 @@ function loadFEDS() {
     ? `adobe-express/ax-gnav${isHomepage ? '-homepage' : ''}`
     : 'cc-express/cc-express-gnav';
 
-  const currentURL = new URL(window.location);
-  const origin = currentURL.origin
-  const linkList = currentURL.pathname.split('/');
-  linkList.shift();
-  const breadcrumbList = [];
-  let buildPath = `${origin}/`;
-  linkList.forEach((pathName) => {
-    buildPath += `${pathName}/`;
-    breadcrumbList.push({ title: pathName, url: buildPath });
-  });
+  const breadCrumbList = [{ title: 'Homepage', url: 'https://www.adobe.com/express' }];
+  const category = window.location.pathname.split('/')[2];
+  const categoryCapitalized = category.charAt(0).toUpperCase() + category.slice(1);
+  const secondBreadcrumb = { title: categoryCapitalized, url: `https://www.adobe.com/express/${category}` };
+  if (['create', 'feature', 'template'].includes(category.toLowerCase())) {
+    const thirdBreadcrumbName = document.querySelector('meta[name="short-title"]').getAttribute('content') || '';
+    const thirdBreadcrumb = { title: thirdBreadcrumbName, url: `${secondBreadcrumb.url}/${thirdBreadcrumbName}` };
+    breadCrumbList.push(secondBreadcrumb, thirdBreadcrumb);
+  }
+
+  const test = document.querySelector('header')
+  const subnav = createTag('div', { id: 'feds-subnav' });
+  test.append(subnav);
 
   window.fedsConfig = {
     ...(window.fedsConfig || {}),
@@ -171,9 +174,9 @@ function loadFEDS() {
       },
     },
     locale: (locale === 'us' ? 'en' : locale),
-    content: {
-      experience: getMetadata('gnav') || fedsExp,
-    },
+    // content: {
+    //   experience: getMetadata('gnav') || fedsExp,
+    // },
     profile: {
       customSignIn: () => {
         const sparkLang = getLanguage(locale);
@@ -197,8 +200,8 @@ function loadFEDS() {
       }
       : {},
     breadcrumbs: {
-      showLogo: true,
-      links: breadcrumbList,
+      showLogo: false,
+      links: breadCrumbList,
     },
   };
 

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -165,16 +165,15 @@ function loadFEDS() {
     let pathList = window.location.pathname.split('/');
     pathList = pathList.filter((element) => element !== '');
     pathList = pathList.filter((element) => element !== locale);
-    const localePath = locale !== 'us' ? `${locale}/` : '';
+    const localePath = locale === 'us' ? '' : `${locale}/`;
     const firstBreadCrumb = buildBreadCrumb(`${localePath}express/`, 'Homepage');
     let category = pathList[1].toLowerCase();
     const categoryURL = category;
+    const pagesShortName = pathList.length > 2
+      ? document.querySelector('meta[name="short-title"]').getAttribute('content')
+      : true;
 
-    if (isHomepage) {
-      return;
-    }
-    if (!validCategories.includes(pathList[1])) {
-      breadCrumbList.push(firstBreadCrumb);
+    if (isHomepage || !pagesShortName) {
       return;
     }
     if (placeholders[category]) {
@@ -182,34 +181,17 @@ function loadFEDS() {
       validCategories.push(category);
     }
 
-    const secondBreadCrumb = buildBreadCrumb(categoryURL, category, `/${locale}/express`);
-    let pagesShortName;
-    if (document.querySelector('meta[name="short-title"]') && pathList.length === 3) {
-      pagesShortName = document.querySelector('meta[name="short-title"]').getAttribute('content') || '';
-    }
-    if (pathList.length === 3 && !pagesShortName) {
+    const secondBreadCrumb = buildBreadCrumb(categoryURL, category, `${localePath}/express`);
+
+    if (!validCategories.includes(category)) {
+      breadCrumbList.push(firstBreadCrumb, secondBreadCrumb);
       return;
     }
 
-    let thirdBreadCrumb;
-    if (pathList.length === 3) {
-      thirdBreadCrumb = buildBreadCrumb(pagesShortName, pagesShortName, secondBreadCrumb.url);
-    } else if (pathList.length > 3) {
-      thirdBreadCrumb = buildBreadCrumb(pathList[2], pathList[2], secondBreadCrumb.url);
-    }
-
-    breadCrumbList.push(firstBreadCrumb);
-    if (validCategories.includes(category)) {
-      breadCrumbList.push(secondBreadCrumb);
-    }
+    breadCrumbList.push(firstBreadCrumb, secondBreadCrumb);
     if (pathList.length >= 3) {
+      const thirdBreadCrumb = buildBreadCrumb(pagesShortName, pagesShortName, secondBreadCrumb.url);
       breadCrumbList.push(thirdBreadCrumb);
-    }
-
-    let runningURL = secondBreadCrumb.url;
-    for (let i = breadCrumbList.length; i < pathList.length; i += 1) {
-      breadCrumbList.push(buildBreadCrumb(pathList[i], pathList[i], runningURL));
-      runningURL = `${runningURL}/${pathList[i]}`;
     }
   }
 
@@ -224,6 +206,7 @@ function loadFEDS() {
     },
     locale: (locale === 'us' ? 'en' : locale),
     // content: {
+    //   experience: 'adobe-express/ax-gnav-homepage',
     //   experience: getMetadata('gnav') || fedsExp,
     // },
     profile: {

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -152,26 +152,25 @@ function loadFEDS() {
     ? `adobe-express/ax-gnav${isHomepage ? '-homepage' : ''}`
     : 'cc-express/cc-express-gnav';
 
-  const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
-  function buildBreadCrumb(path, name, parentPath = '') {
-    return { title: capitalize(name), url: `${parentPath}/${path}` };
-  }
-
   const breadCrumbList = [];
   async function buildBreadCrumbArray() {
+    const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
+    const buildBreadCrumb = (path, name, parentPath = '') => (
+      { title: capitalize(name), url: `${parentPath}/${path}` }
+    );
+
     const placeholders = await fetchPlaceholders();
     const validCategories = ['create', 'feature', 'templates'];
-    const pathList = window.location.pathname.split('/')
+    const pathSegments = window.location.pathname.split('/')
       .filter((element) => element !== '')
       .filter((element) => element !== locale);
     const localePath = locale === 'us' ? '' : `${locale}/`;
-    let category = pathList[1].toLowerCase();
-    const categoryURL = category;
-    const pagesShortName = pathList.length > 2
-      ? document.querySelector('meta[name="short-title"]').getAttribute('content')
-      : true;
+    let category = pathSegments[1].toLowerCase();
+    const secondPathSegment = category;
+    const pagesShortNameElement = document.querySelector('meta[name="short-title"]');
+    const pagesShortName = pagesShortNameElement ? pagesShortNameElement.getAttribute('content') : null;
 
-    if (isHomepage || !pagesShortName) {
+    if (isHomepage || (!pagesShortName && pathSegments.length > 2)) {
       return;
     }
     if (placeholders[category]) {
@@ -179,14 +178,14 @@ function loadFEDS() {
       validCategories.push(category);
     }
 
-    const secondBreadCrumb = buildBreadCrumb(categoryURL, category, `${localePath}/express`);
+    const secondBreadCrumb = buildBreadCrumb(secondPathSegment, category, `${localePath}/express`);
     breadCrumbList.push(secondBreadCrumb);
 
     if (!validCategories.includes(category)) {
       return;
     }
 
-    if (pathList.length >= 3) {
+    if (pathSegments.length >= 3) {
       const thirdBreadCrumb = buildBreadCrumb(pagesShortName, pagesShortName, secondBreadCrumb.url);
       breadCrumbList.push(thirdBreadCrumb);
     }

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -202,7 +202,7 @@ function loadFEDS() {
     },
     locale: (locale === 'us' ? 'en' : locale),
     content: {
-      // experience: 'adobe-express/ax-gnav-homepage',
+      experience: 'adobe-express/ax-gnav-homepage',
       // experience: "adobe-express/ax-gnav"
       // experience: getMetadata('gnav') || fedsExp,
     },

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -153,7 +153,6 @@ function loadFEDS() {
     : 'cc-express/cc-express-gnav';
 
   const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
-
   function buildBreadCrumb(path, name, parentPath = '') {
     return { title: capitalize(name), url: `${parentPath}/${path}` };
   }
@@ -162,11 +161,10 @@ function loadFEDS() {
   async function buildBreadCrumbArray() {
     const placeholders = await fetchPlaceholders();
     const validCategories = ['create', 'feature', 'templates'];
-    let pathList = window.location.pathname.split('/');
-    pathList = pathList.filter((element) => element !== '');
-    pathList = pathList.filter((element) => element !== locale);
+    const pathList = window.location.pathname.split('/')
+      .filter((element) => element !== '')
+      .filter((element) => element !== locale);
     const localePath = locale === 'us' ? '' : `${locale}/`;
-    const firstBreadCrumb = buildBreadCrumb(`${localePath}express/`, 'Homepage');
     let category = pathList[1].toLowerCase();
     const categoryURL = category;
     const pagesShortName = pathList.length > 2
@@ -182,13 +180,12 @@ function loadFEDS() {
     }
 
     const secondBreadCrumb = buildBreadCrumb(categoryURL, category, `${localePath}/express`);
+    breadCrumbList.push(secondBreadCrumb);
 
     if (!validCategories.includes(category)) {
-      breadCrumbList.push(firstBreadCrumb, secondBreadCrumb);
       return;
     }
 
-    breadCrumbList.push(firstBreadCrumb, secondBreadCrumb);
     if (pathList.length >= 3) {
       const thirdBreadCrumb = buildBreadCrumb(pagesShortName, pagesShortName, secondBreadCrumb.url);
       breadCrumbList.push(thirdBreadCrumb);
@@ -205,10 +202,11 @@ function loadFEDS() {
       },
     },
     locale: (locale === 'us' ? 'en' : locale),
-    // content: {
-    //   experience: 'adobe-express/ax-gnav-homepage',
-    //   experience: getMetadata('gnav') || fedsExp,
-    // },
+    content: {
+      // experience: 'adobe-express/ax-gnav-homepage',
+      // experience: "adobe-express/ax-gnav"
+      // experience: getMetadata('gnav') || fedsExp,
+    },
     profile: {
       customSignIn: () => {
         const sparkLang = getLanguage(locale);
@@ -232,7 +230,7 @@ function loadFEDS() {
       }
       : {},
     breadcrumbs: {
-      showLogo: false,
+      showLogo: true,
       links: breadCrumbList,
     },
   };


### PR DESCRIPTION
Fix: https://jira.corp.adobe.com/browse/MWPW-122517

**Test URLs:**
- Before: https://main--express-website--webistry-development.hlx.page/express/create/banner
- After: https://mwpw-122517--express-website--webistry-development.hlx.page/express/create/banner?lighthouse=on

Enables breadcrumbs on Express pages, with the exception of some cases, outlined in the ticket.

**A few notes on the configuration:**
- Category (Create, Templates, etc.) must have translation in its respective placeholder sheet for breadcrumbs to generate. I have gone ahead and added 'Create' on US placeholder for testing purposes.
- Breadcrumbs have been disabled on all international locales until translations are complete.
- Breadcrumbs can be disabled on any specific page by adding the following Metadata. "hide-breadcrumbs: true"
- Feds will handle the translations of "Home", this has been staged to go live. This is not a blocker, as the international sites will not have breadcrumbs enabled until translations are complete for the category.