### PR TITLE
hotfix[pricing-hub]: fix the scroll to account for the gnav

### DIFF
--- a/express/blocks/pricing-hub/pricing-hub.js
+++ b/express/blocks/pricing-hub/pricing-hub.js
@@ -335,7 +335,7 @@ async function decorateScrollOverlay(block) {
     const scrollToCard = (e) => {
       if (e.target.tagName === 'A') return;
       window.scrollTo({
-        top: document.querySelector(`.pricing-hub-cards > :nth-child(${index + 1})`).getBoundingClientRect().top + window.scrollY - 30,
+        top: document.querySelector(`.pricing-hub-cards > :nth-child(${index + 1})`).getBoundingClientRect().top + window.scrollY - 85,
         behavior: 'smooth',
       });
     };


### PR DESCRIPTION
Fix https://jira.corp.adobe.com/browse/MWPW-122824

Test URLs:

Before: https://main--express-website--adobe.hlx.page/express/pricing
After: https://pricing-hotfix--express-website--webistry-development.hlx.page/express/pricing?lighthouse=on

I fixed the scroll so that the cards wouldn't be hidden by the gnav when scrolling up. It's recommended to disabled CORS security in order to review this change as the global nav doesn't load on the Webistry testing branches.

I have otherwise tested the functionality and it works appropriately for me.