### PR TITLE
[MWPW-122680] Plans Comparison: Dynamic Header Icon Color

### DIFF
--- a/express/blocks/plans-comparison/plans-comparison.css
+++ b/express/blocks/plans-comparison/plans-comparison.css
@@ -264,6 +264,10 @@ main .plans-comparison-container .plans-comparison .plans-comparison-cards .plan
     border: none;
 }
 
+main .plans-comparison-container .plans-comparison .plans-comparison-cards .plans-comparison-card.card-free.expanded .icon-pricingfree {
+    fill: var(--color-white);
+}
+
 main .plans-comparison-container .plans-comparison .plans-comparison-cards .plans-comparison-card.expanded .features-wrapper {
     display: block;
     opacity: 1;

--- a/express/blocks/plans-comparison/plans-comparison.js
+++ b/express/blocks/plans-comparison/plans-comparison.js
@@ -321,8 +321,10 @@ export default async function decorate($block) {
     let payload;
     const $linkList = enclosingMain.querySelector('.link-list-container');
     const $section = await fetchPlainBlockFromFragment($block, '/express/fragments/plans-comparison', 'plans-comparison');
-    $section.style.display = 'none';
+
     if ($section) {
+      // hide section to avoid showing broken block
+      $section.style.display = 'none';
       if ($linkList) {
         $linkList.before($section);
       }

--- a/express/blocks/plans-comparison/plans-comparison.js
+++ b/express/blocks/plans-comparison/plans-comparison.js
@@ -321,7 +321,7 @@ export default async function decorate($block) {
     let payload;
     const $linkList = enclosingMain.querySelector('.link-list-container');
     const $section = await fetchPlainBlockFromFragment($block, '/express/fragments/plans-comparison', 'plans-comparison');
-
+    $section.style.display = 'none';
     if ($section) {
       if ($linkList) {
         $linkList.before($section);
@@ -339,6 +339,7 @@ export default async function decorate($block) {
 
         if ($cards) {
           setTimeout(() => {
+            $section.style.removeProperty('display');
             toggleExpandableCard($blockFromFragment, $cards[1], payload, true);
             resizeCards($cards, $featuresWrappers, payload);
             payload.desiredHeight = `${$featuresWrappers[1].offsetHeight}px`;


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix [MWPW-122680](https://jira.corp.adobe.com/browse/MWPW-122680)

**Description:**
- Added dynamically changing color to the free plan header icon (template + lightning), active=white, inactive=black
- Hide plans comparison during rendering to avoid showing a broken block

**Test URLs:**
- Before: https://main--express-website--adobe.hlx.page/express/create/flyer?lighthouse=on
- After: https://mwpw-122680--express-website--webistry-development.hlx.page/express/create/flyer?lighthouse=on
