### PR TITLE
fix: prevent right click and download for the image and style issues

### DIFF
--- a/express/experiments/ccx0027/blocks/quick-action1/quick-action.css
+++ b/express/experiments/ccx0027/blocks/quick-action1/quick-action.css
@@ -16,6 +16,10 @@ ccl-quick-action .button-container {
     align-items: baseline;
 }
 
+ccl-quick-action.quick-action-completed cclqt-remove-background {
+    pointer-events: none;
+}
+
 ccl-quick-action .quick-action-complete-overlay a[data-action='Download'] {
     display: flex;
     flex: 0 0 158px;
@@ -45,6 +49,7 @@ ccl-quick-action a[data-action='Download'] lottie-player {
 /* mock-ccl-quick-action styles */
 
 .mock-ccl-quick-action {
+    position: relative;
     display: flex;
     flex: 0 0 600px;
     width: 600px;
@@ -211,16 +216,17 @@ ccl-quick-action:hover .quick-action-complete-overlay-container {
 .quick-action-complete-overlay-container {
     display: block;
     position: absolute;
-    top: 87px;
+    top: 77px;
     bottom: 0;
     left: -48px;
     right: 0;
-    height: 400px;
+    height: 420px;
     width: 600px;
     opacity: 0;
     margin: 0 auto;
     transition: .5s ease;
     background: linear-gradient(to bottom, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.70));
+    border-radius: 0.75rem;
 }
 
 .quick-action-complete-overlay-container .quick-action-complete-overlay {
@@ -239,7 +245,7 @@ ccl-quick-action:hover .quick-action-complete-overlay-container {
     position: absolute;
     width: 42px;
     height: 42px;
-    top: 64px;
+    top: 54px;
     right: 60px;
     z-index: 1000;
     box-shadow: 0 0 6px 6px rgb(0 0 0 / 4%);

--- a/express/experiments/ccx0027/blocks/quick-action2/quick-action.css
+++ b/express/experiments/ccx0027/blocks/quick-action2/quick-action.css
@@ -22,6 +22,7 @@ ccl-quick-action cclqt-remove-background {
 
 ccl-quick-action.quick-action-completed cclqt-remove-background {
     margin-right: 0;
+    pointer-events: none;
 }
 
 ccl-quick-action .quick-action-complete-overlay a.overlay-item {
@@ -41,6 +42,7 @@ ccl-quick-action a[data-action='Download'] lottie-player {
 /* mock-ccl-quick-action styles */
 
 .mock-ccl-quick-action {
+    position: relative;
     display: flex;
     flex: 0 0 600px;
     width: 600px;
@@ -249,15 +251,16 @@ ccl-quick-action .more-quick-actions-container p {
 .quick-action-complete-overlay-container {
     display: block;
     position: absolute;
-    top: 37px;
+    top: 27px;
     bottom: 0;
     left: -160px;
     right: 0;
-    height: 400px;
+    height: 420px;
     width: 600px;
     margin: 0 auto;
     transition: .5s ease;
     background: linear-gradient(to bottom, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.70));
+    border-radius: 0.75rem;
 }
 
 .quick-action-complete-overlay-container .quick-action-complete-overlay {
@@ -280,7 +283,7 @@ ccl-quick-action .more-quick-actions-container p {
     position: absolute;
     width: 42px;
     height: 42px;
-    top: 16px;
+    top: 6px;
     right: 358px;
     z-index: 1000;
     box-shadow: 0 0 6px 6px rgb(0 0 0 / 4%);


### PR DESCRIPTION
- adding pointer-events to none on the converted image so that users can't right click and dowonload
- fix style issues

Fix [SITES-11254](https://jira.corp.adobe.com/browse/SITES-11254)

Test URLs:

https://quick-action-embed-frictionless--express-website--ravkiran.hlx.page/express/experiments/ccx0027/quick-action?experiment=ccx0027%2Fchallenger-1
