### PR TITLE
fix: adjusting the height of utility in c1 so that it doesn't break into the next section

### DIFF
--- a/express/blocks/quick-action/shared.js
+++ b/express/blocks/quick-action/shared.js
@@ -77,8 +77,10 @@ export class CCXQuickActionElement extends HTMLElement {
         if (!state.editorLoading && state.exportEnabled) {
           const quickActionCompletionEvent = new Event('ccl-quick-action-complete');
           document.querySelector(ELEMENT_NAME).dispatchEvent(quickActionCompletionEvent);
+          this.buttonContainer.style.display = 'block';
+        } else {
+          this.buttonContainer.style.display = 'none';
         }
-        this.buttonContainer.style.display = state.exportEnabled ? 'block' : 'none';
       },
       // eslint-disable-next-line no-console
       sendErrorToHost(err) { console.error('[CCLQT CB]', 'error', err); },

--- a/express/experiments/ccx0027/blocks/quick-action1/quick-action.css
+++ b/express/experiments/ccx0027/blocks/quick-action1/quick-action.css
@@ -18,6 +18,7 @@ ccl-quick-action .button-container {
 
 ccl-quick-action.quick-action-completed cclqt-remove-background {
     pointer-events: none;
+    height: 475px;
 }
 
 ccl-quick-action .quick-action-complete-overlay a[data-action='Download'] {

--- a/express/experiments/ccx0027/blocks/quick-action1/quick-action.js
+++ b/express/experiments/ccx0027/blocks/quick-action1/quick-action.js
@@ -17,7 +17,7 @@ import { CCXQuickActionElement, ELEMENT_NAME } from '../../../../blocks/quick-ac
 
 const MOCK_ELEMENT_NAME = `mock-${ELEMENT_NAME}`;
 const BLOCK_NAME = '.quick-action';
-const QUICKACTION_HEIGHT_IN_PX = '475px';
+const QUICKACTION_HEIGHT_IN_PX = '525px';
 const QUICK_TASK_CLOSE_BUTTON = 'quick-task-close-button';
 const QUICK_ACTION_COMPLETED = 'quick-action-completed';
 const LOTTIE_ICONS = {

--- a/express/experiments/ccx0027/blocks/quick-action2/quick-action.css
+++ b/express/experiments/ccx0027/blocks/quick-action2/quick-action.css
@@ -211,6 +211,7 @@ ccl-quick-action .more-quick-actions-container p {
     text-align: left;
     width: 200px;
     margin-bottom: 0;
+    margin-top: 20px;
     font-size: var(--body-font-size-xl);
 }
 


### PR DESCRIPTION
due to the `cclqt-remove-background` occupying the 100% of container, the experience is broken 
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/1553152/224402668-d862265b-ba0c-4feb-95d4-67c613fccc6c.png">
As a fix, setting the height for `cclqt-remove-background` while counting 50px for download button container above the utility.

Fix [SITES-11254](https://jira.corp.adobe.com/browse/SITES-11254)

Test URLs:
https://frictionless-c1-height--express-website--ravkiran.hlx.page/express/feature/image/remove-background?experiment=ccx0027%2Fchallenger-1