### PR TITLE
fix: adding legal copy to the quick action test variants

### DIFF
--- a/express/experiments/ccx0027/blocks/quick-action1/quick-action.css
+++ b/express/experiments/ccx0027/blocks/quick-action1/quick-action.css
@@ -52,7 +52,6 @@ ccl-quick-action a[data-action='Download'] lottie-player {
 .mock-ccl-quick-action {
     position: relative;
     display: flex;
-    flex: 0 0 600px;
     width: 600px;
     height: 320px;
     justify-content: center;
@@ -138,6 +137,16 @@ ccl-quick-action a.button[data-action="Download"]:focus {
 
 .mock-ccl-quick-action #mock-file-input {
     display: none;
+}
+
+.mock-ccl-quick-action-container .quick-action-legal-copy {
+    margin: 16px 0 0 50px;
+    font-size: 12px;
+    color: #444444;
+}
+
+.mock-ccl-quick-action-container .quick-action-legal-copy a {
+    color: #4646C6;
 }
 
 .quick-action-tag {

--- a/express/experiments/ccx0027/blocks/quick-action1/quick-action.css
+++ b/express/experiments/ccx0027/blocks/quick-action1/quick-action.css
@@ -142,7 +142,7 @@ ccl-quick-action a.button[data-action="Download"]:focus {
 .mock-ccl-quick-action-container .quick-action-legal-copy {
     margin: 16px 0 0 50px;
     font-size: 12px;
-    color: #444444;
+    color: #444;
 }
 
 .mock-ccl-quick-action-container .quick-action-legal-copy a {

--- a/express/experiments/ccx0027/blocks/quick-action1/quick-action.js
+++ b/express/experiments/ccx0027/blocks/quick-action1/quick-action.js
@@ -16,6 +16,7 @@ import {
 import { CCXQuickActionElement, ELEMENT_NAME } from '../../../../blocks/quick-action/shared.js';
 
 const MOCK_ELEMENT_NAME = `mock-${ELEMENT_NAME}`;
+const MOCK_ELEMENT_CONTAINER = `${MOCK_ELEMENT_NAME}-container`;
 const BLOCK_NAME = '.quick-action';
 const QUICKACTION_HEIGHT_IN_PX = '525px';
 const QUICK_TASK_CLOSE_BUTTON = 'quick-task-close-button';
@@ -25,6 +26,8 @@ const LOTTIE_ICONS = {
 };
 
 function createMockQuickAction() {
+  const container = document.createElement('div');
+  container.className = MOCK_ELEMENT_CONTAINER;
   const ele = document.createElement('div');
   ele.className = MOCK_ELEMENT_NAME;
   ele.innerHTML = '<div class="dropzone"><div class="dropzone__bg" '
@@ -38,6 +41,17 @@ function createMockQuickAction() {
   + '<div class="quick-action-tag-container"><div class="quick-action-tag"><img class="icon icon-checkmark" src="/express/icons/checkmark.svg" alt="checkmark"></div>No credit card required</div>'
   + '</div> <input id="mock-file-input" type="file" accept="image/jpeg,image/png">'
   + '</div>';
+  container.append(ele);
+  container.append(createLegalCopy());
+  return container;
+}
+
+function createLegalCopy() {
+  const ele = document.createElement("div");
+  ele.className = "quick-action-legal-copy";
+  ele.innerHTML =
+    'By uploading your image or video, you are agreeing to the Adobe <a href="https://adobe.com/go/terms_en">Terms of Use</a>' +
+    ' and <a href="https://adobe.com/go/privacy_policy_en">Privacy Policy</a>.';
   return ele;
 }
 
@@ -109,7 +123,7 @@ function addListenersOnMockElements(ele) {
     video.parentNode.appendChild(picture);
   });
   document.querySelector(ELEMENT_NAME).addEventListener('ccl-show-quick-action', () => {
-    document.getElementsByClassName(MOCK_ELEMENT_NAME)[0].parentNode.style.display = 'none';
+    document.getElementsByClassName(MOCK_ELEMENT_CONTAINER)[0].parentNode.style.display = 'none';
     document.querySelector(ELEMENT_NAME).style.height = QUICKACTION_HEIGHT_IN_PX;
   });
   document.querySelector(ELEMENT_NAME).addEventListener('ccl-quick-action-complete', () => {

--- a/express/experiments/ccx0027/blocks/quick-action1/quick-action.js
+++ b/express/experiments/ccx0027/blocks/quick-action1/quick-action.js
@@ -25,6 +25,14 @@ const LOTTIE_ICONS = {
   'arrow-up': '/express/icons/arrow-up-lottie.json',
 };
 
+function createLegalCopy() {
+  const ele = document.createElement('div');
+  ele.className = 'quick-action-legal-copy';
+  ele.innerHTML = 'By uploading your image or video, you are agreeing to the Adobe <a href="https://adobe.com/go/terms_en">Terms of Use</a>'
+    + ' and <a href="https://adobe.com/go/privacy_policy_en">Privacy Policy</a>.';
+  return ele;
+}
+
 function createMockQuickAction() {
   const container = document.createElement('div');
   container.className = MOCK_ELEMENT_CONTAINER;
@@ -44,15 +52,6 @@ function createMockQuickAction() {
   container.append(ele);
   container.append(createLegalCopy());
   return container;
-}
-
-function createLegalCopy() {
-  const ele = document.createElement("div");
-  ele.className = "quick-action-legal-copy";
-  ele.innerHTML =
-    'By uploading your image or video, you are agreeing to the Adobe <a href="https://adobe.com/go/terms_en">Terms of Use</a>' +
-    ' and <a href="https://adobe.com/go/privacy_policy_en">Privacy Policy</a>.';
-  return ele;
 }
 
 function addLottieIcons(array, lottieIcon) {

--- a/express/experiments/ccx0027/blocks/quick-action2/quick-action.css
+++ b/express/experiments/ccx0027/blocks/quick-action2/quick-action.css
@@ -136,7 +136,7 @@ ccl-quick-action a[data-action='Download'] lottie-player {
 .mock-ccl-quick-action-container .quick-action-legal-copy {
     margin: 16px 0 0 50px;
     font-size: 12px;
-    color: #444444;
+    color: #444;
 }
 
 .mock-ccl-quick-action-container .quick-action-legal-copy a {

--- a/express/experiments/ccx0027/blocks/quick-action2/quick-action.css
+++ b/express/experiments/ccx0027/blocks/quick-action2/quick-action.css
@@ -44,7 +44,6 @@ ccl-quick-action a[data-action='Download'] lottie-player {
 .mock-ccl-quick-action {
     position: relative;
     display: flex;
-    flex: 0 0 600px;
     width: 600px;
     height: 320px;
     justify-content: center;
@@ -132,6 +131,16 @@ ccl-quick-action a[data-action='Download'] lottie-player {
 
 .mock-ccl-quick-action #mock-file-input {
     display: none;
+}
+
+.mock-ccl-quick-action-container .quick-action-legal-copy {
+    margin: 16px 0 0 50px;
+    font-size: 12px;
+    color: #444444;
+}
+
+.mock-ccl-quick-action-container .quick-action-legal-copy a {
+    color: #4646C6;
 }
 
 .quick-action-tag {

--- a/express/experiments/ccx0027/blocks/quick-action2/quick-action.js
+++ b/express/experiments/ccx0027/blocks/quick-action2/quick-action.js
@@ -26,6 +26,14 @@ const LOTTIE_ICONS = {
   'arrow-up': '/express/icons/arrow-up-lottie.json',
 };
 
+function createLegalCopy() {
+  const ele = document.createElement('div');
+  ele.className = 'quick-action-legal-copy';
+  ele.innerHTML = 'By uploading your image or video, you are agreeing to the Adobe <a href="https://adobe.com/go/terms_en">Terms of Use</a>'
+    + ' and <a href="https://adobe.com/go/privacy_policy_en">Privacy Policy</a>.';
+  return ele;
+}
+
 function createMockQuickAction() {
   const container = document.createElement('div');
   container.className = MOCK_ELEMENT_CONTAINER;
@@ -45,15 +53,6 @@ function createMockQuickAction() {
   container.append(ele);
   container.append(createLegalCopy());
   return container;
-}
-
-function createLegalCopy() {
-  const ele = document.createElement("div");
-  ele.className = "quick-action-legal-copy";
-  ele.innerHTML =
-    'By uploading your image or video, you are agreeing to the Adobe <a href="https://adobe.com/go/terms_en">Terms of Use</a>' +
-    ' and <a href="https://adobe.com/go/privacy_policy_en">Privacy Policy</a>.';
-  return ele;
 }
 
 function addLottieIcons(array, lottieIcon) {

--- a/express/experiments/ccx0027/blocks/quick-action2/quick-action.js
+++ b/express/experiments/ccx0027/blocks/quick-action2/quick-action.js
@@ -17,6 +17,7 @@ import { CCXQuickActionElement, ELEMENT_NAME } from '../../../../blocks/quick-ac
 
 const REMOVE_BACKGROUND_ELEMENT = 'cclqt-remove-background';
 const MOCK_ELEMENT_NAME = `mock-${ELEMENT_NAME}`;
+const MOCK_ELEMENT_CONTAINER = `${MOCK_ELEMENT_NAME}-container`;
 const BLOCK_NAME = '.quick-action';
 const QUICKACTION_HEIGHT_IN_PX = '475px';
 const QUICK_TASK_CLOSE_BUTTON = 'quick-task-close-button';
@@ -26,6 +27,8 @@ const LOTTIE_ICONS = {
 };
 
 function createMockQuickAction() {
+  const container = document.createElement('div');
+  container.className = MOCK_ELEMENT_CONTAINER;
   const ele = document.createElement('div');
   ele.className = MOCK_ELEMENT_NAME;
   ele.innerHTML = '<div class="dropzone"><div class="dropzone__bg" '
@@ -39,6 +42,17 @@ function createMockQuickAction() {
   + '<div class="quick-action-tag-container"><div class="quick-action-tag"><img class="icon icon-checkmark" src="/express/icons/checkmark.svg" alt="checkmark"></div>No credit card required</div>'
   + '</div> <input id="mock-file-input" type="file" accept="image/jpeg,image/png">'
   + '</div>';
+  container.append(ele);
+  container.append(createLegalCopy());
+  return container;
+}
+
+function createLegalCopy() {
+  const ele = document.createElement("div");
+  ele.className = "quick-action-legal-copy";
+  ele.innerHTML =
+    'By uploading your image or video, you are agreeing to the Adobe <a href="https://adobe.com/go/terms_en">Terms of Use</a>' +
+    ' and <a href="https://adobe.com/go/privacy_policy_en">Privacy Policy</a>.';
   return ele;
 }
 
@@ -123,7 +137,7 @@ function addListenersOnMockElements(ele) {
     video.parentNode.appendChild(picture);
   });
   document.querySelector(ELEMENT_NAME).addEventListener('ccl-show-quick-action', () => {
-    document.getElementsByClassName(MOCK_ELEMENT_NAME)[0].parentNode.style.display = 'none';
+    document.getElementsByClassName(MOCK_ELEMENT_CONTAINER)[0].parentNode.style.display = 'none';
     document.querySelector(ELEMENT_NAME).style.height = QUICKACTION_HEIGHT_IN_PX;
   });
   document.querySelector(ELEMENT_NAME).addEventListener('ccl-quick-action-complete', () => {


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix: adding legal copy to variants

Test URLs:
https://quickaction-legal-copy--express-website--adobe.hlx.page/express/feature/image/remove-background?experiment=ccx0027%2Fchallenger-1