### PR TITLE
chore: shift mobile breakpoint from 400 to 600px

### DIFF
--- a/express/blocks/app-store-blade/app-store-blade.js
+++ b/express/blocks/app-store-blade/app-store-blade.js
@@ -22,7 +22,7 @@ import {
  * @returns {String}
  */
 
-function createStandardImage(src, alt = '', eager = false, breakpoints = [{ media: '(min-width: 400px)', width: '2000' }, { width: '750' }]) {
+function createStandardImage(src, alt = '', eager = false, breakpoints = [{ media: '(min-width: 600px)', width: '2000' }, { width: '750' }]) {
   const url = new URL(src, window.location.origin);
   const picture = document.createElement('picture');
   const { pathname } = url;

--- a/express/blocks/cards/cards.css
+++ b/express/blocks/cards/cards.css
@@ -98,7 +98,7 @@ main .cards.large .card .card-content li {
   font-size: 1.125rem;
 }
 
-@media (min-width:400px) {
+@media (min-width: 600px) {
   main .cards .card {
     width: 344px;
   }

--- a/express/blocks/download-cards/download-cards.css
+++ b/express/blocks/download-cards/download-cards.css
@@ -99,7 +99,7 @@ main .cards.large .card .card-content li {
   font-size: 1.125rem;
 }
 
-@media (min-width:400px) {
+@media (min-width: 600px) {
   main .cards .card {
     width: 344px;
   }

--- a/express/blocks/download-screens/download-screens.css
+++ b/express/blocks/download-screens/download-screens.css
@@ -115,7 +115,7 @@ main .cards.large .card .card-content li {
   font-size: 1.125rem;
 }
 
-@media (min-width:400px) {
+@media (min-width: 600px) {
   main .cards .card {
     width: 344px;
   }

--- a/express/blocks/hero-animation/hero-animation.css
+++ b/express/blocks/hero-animation/hero-animation.css
@@ -164,7 +164,7 @@ main .hero-animation.white-text a:any-link {
 
 /* Wide option */
 
-@media (min-width: 400px) {
+@media (min-width: 600px) {
   main .hero-animation.wide {
     position: relative;
     max-width: 1200px;

--- a/express/blocks/hero-image/hero-image.css
+++ b/express/blocks/hero-image/hero-image.css
@@ -76,7 +76,7 @@ main .hero-image .hero-image-overlay p.button-container a.button:any-link {
 }
 
 
-@media (min-width: 400px) {
+@media (min-width: 600px) {
     main .hero-image {
         padding-top: max( 49%, 375px);
     }
@@ -89,7 +89,7 @@ main .hero-image .hero-image-overlay p.button-container a.button:any-link {
 }
 
 @media (min-width: 740px) {
-    
+
     /* body.no-desktop-brand-header header, body.no-brand-header header {
         height: 64px;
         background-image: unset;
@@ -97,7 +97,7 @@ main .hero-image .hero-image-overlay p.button-container a.button:any-link {
 
     main .hero-image {
         padding-top: 0;
-    }    
+    }
 
     main .hero-image-container > div {
         padding: 0 56px;
@@ -110,7 +110,7 @@ main .hero-image .hero-image-overlay p.button-container a.button:any-link {
         margin: unset;
         padding: 0;
     }
-    
+
     main .hero-image h1 {
         font-size: var(--heading-font-size-xxl);
     }
@@ -120,5 +120,5 @@ main .hero-image .hero-image-overlay p.button-container a.button:any-link {
 @media (min-width: 1800px) {
     main .hero-image-container > div {
         max-width: 65%;
-    }    
+    }
 }

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -1743,7 +1743,7 @@ export async function decorateTemplateList($block) {
   if (rows === 1) {
     $block.classList.add('large');
     breakpoints = [{
-      media: '(min-width: 400px)',
+      media: '(min-width: 600px)',
       width: '2000',
     }, { width: '750' }];
   }

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1985,7 +1985,7 @@ function displayEnv() {
  * @param {Array} breakpoints breakpoints and corresponding params (eg. width)
  */
 
-export function createOptimizedPicture(src, alt = '', eager = false, breakpoints = [{ media: '(min-width: 400px)', width: '2000' }, { width: '750' }]) {
+export function createOptimizedPicture(src, alt = '', eager = false, breakpoints = [{ media: '(min-width: 600px)', width: '2000' }, { width: '750' }]) {
   const url = new URL(src, window.location.href);
   const picture = document.createElement('picture');
   const { pathname } = url;

--- a/test/unit/blocks/expected/link-image.basic.block.html
+++ b/test/unit/blocks/expected/link-image.basic.block.html
@@ -3,7 +3,7 @@
     <div><a href="https://spark.adobe.com/video/FZXqFDNFog5qY" class="">
         <p></p>
         <picture>
-          <source media="(max-width: 400px)"
+          <source media="(max-width: 600px)"
             srcset="./media/a.webp?width=750&amp;auto=webp&amp;format=pjpg&amp;optimize=medium">
           <img
             src="./media/a.webp?width=2000&amp;auto=webp&amp;format=pjpg&amp;optimize=medium"

--- a/test/unit/blocks/expected/link-image.nolinebreaks.block.html
+++ b/test/unit/blocks/expected/link-image.nolinebreaks.block.html
@@ -2,7 +2,7 @@
   <div>
     <div><a href="https://spark.adobe.com/video/FZXqFDNFog5qY" class="">
         <picture>
-          <source media="(max-width: 400px)"
+          <source media="(max-width: 600px)"
             srcset="./media/a.webp?width=750&amp;auto=webp&amp;format=pjpg&amp;optimize=medium">
           <img
             src="./media/a.webp?width=2000&amp;auto=webp&amp;format=pjpg&amp;optimize=medium"

--- a/test/unit/blocks/expected/template-list.linkedimage.block.html
+++ b/test/unit/blocks/expected/template-list.linkedimage.block.html
@@ -2,10 +2,10 @@
     <div class="template">
         <div><a href="https://spark.adobe.com/express-apps/logo-maker/" class="">
             <picture>
-                <source media="(min-width: 400px)" type="image/webp"
+                <source media="(min-width: 600px)" type="image/webp"
                         srcset="/media/a.webp?width=2000&amp;format=webply&amp;optimize=medium">
                 <source type="image/webp" srcset="/media/a.webp?width=750&amp;format=webply&amp;optimize=medium">
-                <source media="(min-width: 400px)"
+                <source media="(min-width: 600px)"
                         srcset="/media/a.webp?width=2000&amp;format=webp&amp;optimize=medium">
                 <img loading="eager" alt="camera logo express app"
                      src="/media/a.webp?width=750&amp;format=webp&amp;optimize=medium"></picture>

--- a/test/unit/blocks/expected/template-list.linkwithtext.block.html
+++ b/test/unit/blocks/expected/template-list.linkwithtext.block.html
@@ -2,10 +2,10 @@
     <a href="https://spark.adobe.com/post/BshlLeOZHhNAy" class="template">
         <div>
             <picture>
-                <source media="(min-width: 400px)" type="image/webp"
+                <source media="(min-width: 600px)" type="image/webp"
                         srcset="/media/a.webp?width=2000&amp;format=webply&amp;optimize=medium">
                 <source type="image/webp" srcset="/media/a.webp?width=750&amp;format=webply&amp;optimize=medium">
-                <source media="(min-width: 400px)" srcset="/media/a.webp?width=2000&amp;format=webp&amp;optimize=medium">
+                <source media="(min-width: 600px)" srcset="/media/a.webp?width=2000&amp;format=webp&amp;optimize=medium">
                 <img loading="eager" alt="" src="/media/a.webp?width=750&amp;format=webp&amp;optimize=medium"></picture>
         </div>
         <div><span class="template-link">Edit this template</span></div>

--- a/test/unit/blocks/expected/template-list.title.block.html
+++ b/test/unit/blocks/expected/template-list.title.block.html
@@ -6,10 +6,10 @@
     <a href="https://adobesparkpost.app.link/pyZwdYuCcZ" class="template">
         <div>
             <picture>
-                <source media="(min-width: 400px)" type="image/webp"
+                <source media="(min-width: 600px)" type="image/webp"
                         srcset="/media/a.webp?width=2000&amp;format=webply&amp;optimize=medium">
                 <source type="image/webp" srcset="/media/a.webp?width=750&amp;format=webply&amp;optimize=medium">
-                <source media="(min-width: 400px)"
+                <source media="(min-width: 600px)"
                         srcset="/media/a.webp?width=2000&amp;format=webp&amp;optimize=medium">
                 <img loading="eager" alt="White With Sea View Social Post"
                      src="/media/a.webp?width=750&amp;format=webp&amp;optimize=medium"></picture>

--- a/test/unit/blocks/input/columns.animation.doc.html
+++ b/test/unit/blocks/input/columns.animation.doc.html
@@ -10,7 +10,7 @@
       <div>
         <p>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/a.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/a.webp?width=2000&amp;format=webply&amp;optimize=medium"

--- a/test/unit/blocks/input/columns.animation.params.doc.html
+++ b/test/unit/blocks/input/columns.animation.params.doc.html
@@ -10,7 +10,7 @@
       <div>
         <p>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/a.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/a.webp?width=2000&amp;format=webply&amp;optimize=medium"

--- a/test/unit/blocks/input/link-image.basic.doc.html
+++ b/test/unit/blocks/input/link-image.basic.doc.html
@@ -4,7 +4,7 @@
       <div>
         <p></p>
         <picture>
-          <source media="(max-width: 400px)"
+          <source media="(max-width: 600px)"
             srcset="./media/a.webp?width=750&amp;auto=webp&amp;format=pjpg&amp;optimize=medium">
           <img
             src="./media/a.webp?width=2000&amp;auto=webp&amp;format=pjpg&amp;optimize=medium"

--- a/test/unit/blocks/input/link-image.nolinebreaks.doc.html
+++ b/test/unit/blocks/input/link-image.nolinebreaks.doc.html
@@ -3,7 +3,7 @@
     <div>
       <div>
         <picture>
-          <source media="(max-width: 400px)"
+          <source media="(max-width: 600px)"
             srcset="./media/a.webp?width=750&amp;auto=webp&amp;format=pjpg&amp;optimize=medium">
           <img
             src="./media/a.webp?width=2000&amp;auto=webp&amp;format=pjpg&amp;optimize=medium"

--- a/test/unit/blocks/input/template-list.horizontal.doc.html
+++ b/test/unit/blocks/input/template-list.horizontal.doc.html
@@ -3,7 +3,7 @@
     <div>
       <div>
         <picture>
-          <source media="(max-width: 400px)"
+          <source media="(max-width: 600px)"
             srcset="./media/a.webp?width=750&amp;format=webply&amp;optimize=medium">
           <img
             src="./media/a.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -15,7 +15,7 @@
     <div>
       <div>
         <picture>
-          <source media="(max-width: 400px)"
+          <source media="(max-width: 600px)"
             srcset="./media/b.webp?width=750&amp;format=webply&amp;optimize=medium">
           <img
             src="./media/b.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -27,7 +27,7 @@
     <div>
       <div>
         <picture>
-          <source media="(max-width: 400px)"
+          <source media="(max-width: 600px)"
             srcset="./media/c.webp?width=750&amp;format=webply&amp;optimize=medium">
           <img
             src="./media/c.webp?width=2000&amp;format=webply&amp;optimize=medium"

--- a/test/unit/blocks/input/template-list.linkedimage.doc.html
+++ b/test/unit/blocks/input/template-list.linkedimage.doc.html
@@ -3,7 +3,7 @@
     <div>
       <div>
         <picture>
-          <source media="(max-width: 400px)"
+          <source media="(max-width: 600px)"
             srcset="./media/a.webp?width=750&amp;auto=webp&amp;format=pjpg&amp;optimize=medium">
           <img src="./media/a.webp?width=2000&amp;auto=webp&amp;format=pjpg&amp;optimize=medium"
             alt="camera logo express app" title="camera logo express app" loading="lazy">

--- a/test/unit/blocks/input/template-list.linknotext.doc.html
+++ b/test/unit/blocks/input/template-list.linknotext.doc.html
@@ -4,7 +4,7 @@
       <div>
         <p></p>
         <picture>
-          <source media="(max-width: 400px)"
+          <source media="(max-width: 600px)"
             srcset="./media/a.webp?width=750&amp;auto=webp&amp;format=pjpg&amp;optimize=medium">
           <img
             src="./media/a.webp?width=2000&amp;auto=webp&amp;format=pjpg&amp;optimize=medium"
@@ -18,7 +18,7 @@
     <div>
       <div>
         <picture>
-          <source media="(max-width: 400px)"
+          <source media="(max-width: 600px)"
             srcset="./media/b.webp?width=750&amp;auto=webp&amp;format=pjpg&amp;optimize=medium">
           <img
             src="./media/b.webp?width=2000&amp;auto=webp&amp;format=pjpg&amp;optimize=medium"

--- a/test/unit/blocks/input/template-list.linkwithtext.doc.html
+++ b/test/unit/blocks/input/template-list.linkwithtext.doc.html
@@ -3,7 +3,7 @@
     <div>
       <div>
         <picture>
-          <source media="(max-width: 400px)"
+          <source media="(max-width: 600px)"
             srcset="./media/a.webp?width=750&amp;auto=webp&amp;format=pjpg&amp;optimize=medium">
           <img
             src="./media/a.webp?width=2000&amp;auto=webp&amp;format=pjpg&amp;optimize=medium"

--- a/test/unit/blocks/input/template-list.sixcols.doc.html
+++ b/test/unit/blocks/input/template-list.sixcols.doc.html
@@ -3,7 +3,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/a.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/a.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -15,7 +15,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/b.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/b.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -27,7 +27,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/c.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/c.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -39,7 +39,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/d.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/d.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -51,7 +51,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/a.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/a.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -63,7 +63,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/b.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/b.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -75,7 +75,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/c.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/c.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -87,7 +87,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/d.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/d.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -99,7 +99,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/a.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/a.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -111,7 +111,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/b.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/b.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -123,7 +123,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/c.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/c.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -135,7 +135,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/d.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/d.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -147,7 +147,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/a.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/a.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -159,7 +159,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/b.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/b.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -171,7 +171,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/c.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/c.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -184,7 +184,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/d.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/d.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -196,7 +196,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/a.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/a.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -208,7 +208,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/b.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/b.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -220,7 +220,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/c.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/c.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -232,7 +232,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/d.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/d.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -244,7 +244,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/a.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/a.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -256,7 +256,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/b.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/b.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -268,7 +268,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/c.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/c.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -280,7 +280,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/d.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/d.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -292,7 +292,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/a.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/a.webp?width=2000&amp;format=webply&amp;optimize=medium"
@@ -304,7 +304,7 @@
       <div>
         <div>
           <picture>
-            <source media="(max-width: 400px)"
+            <source media="(max-width: 600px)"
               srcset="./media/b.webp?width=750&amp;format=webply&amp;optimize=medium">
             <img
               src="./media/b.webp?width=2000&amp;format=webply&amp;optimize=medium"

--- a/test/unit/blocks/input/template-list.title.doc.html
+++ b/test/unit/blocks/input/template-list.title.doc.html
@@ -9,7 +9,7 @@
     <div>
       <div>
         <picture>
-          <source media="(max-width: 400px)"
+          <source media="(max-width: 600px)"
             srcset="./media/a.webp?width=750&amp;format=webply&amp;optimize=medium">
           <img
             src="./media/a.webp?width=2000&amp;format=webply&amp;optimize=medium"

--- a/test/unit/blocks/input/template-list.video.doc.html
+++ b/test/unit/blocks/input/template-list.video.doc.html
@@ -3,7 +3,7 @@
     <div>
       <div>
         <picture>
-          <source media="(max-width: 400px)"
+          <source media="(max-width: 600px)"
             srcset="./media/a.webp?width=750&amp;auto=webp&amp;format=pjpg&amp;optimize=medium">
           <img
             src="./media/a.webp?width=2000&amp;auto=webp&amp;format=pjpg&amp;optimize=medium"


### PR DESCRIPTION
Shift mobile breakpoint from 400px to 600px to account for more modern mobile devices with wider screens.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/
- After: https://mobile-breakpoint--express-website--adobe.hlx.page/express/?hlx-pipeline-version=ci4162&lighthouse=on
