### PR TITLE
[HOTFIX]: Fix Missing Plans Comparison

### DIFF
--- a/express/blocks/plans-comparison/plans-comparison.js
+++ b/express/blocks/plans-comparison/plans-comparison.js
@@ -320,16 +320,21 @@ export default async function decorate($block) {
   if (enclosingMain) {
     let payload;
     const $linkList = enclosingMain.querySelector('.link-list-container');
-    const $section = await fetchPlainBlockFromFragment($block, '/express/fragments/plans-comparison', 'plans-comparison');
+    const $oldSection = $block.closest('.section');
+    const $newSection = await fetchPlainBlockFromFragment('/express/fragments/plans-comparison', 'plans-comparison');
 
-    if ($section) {
+    if ($oldSection) {
+      $oldSection.parentNode.replaceChild($newSection, $oldSection);
+    }
+
+    if ($newSection) {
       // hide section to avoid showing broken block
-      $section.style.display = 'none';
+      $newSection.style.display = 'none';
       if ($linkList) {
-        $linkList.before($section);
+        $linkList.before($newSection);
       }
 
-      const $blockFromFragment = $section.querySelector('.plans-comparison');
+      const $blockFromFragment = $newSection.querySelector('.plans-comparison');
       if ($blockFromFragment) {
         payload = await buildPayload($blockFromFragment);
         $blockFromFragment.innerHTML = payload.mainHeading;
@@ -341,7 +346,7 @@ export default async function decorate($block) {
 
         if ($cards) {
           setTimeout(() => {
-            $section.style.removeProperty('display');
+            $newSection.style.removeProperty('display');
             toggleExpandableCard($blockFromFragment, $cards[1], payload, true);
             resizeCards($cards, $featuresWrappers, payload);
             payload.desiredHeight = `${$featuresWrappers[1].offsetHeight}px`;

--- a/express/blocks/quick-action-card/quick-action-card.js
+++ b/express/blocks/quick-action-card/quick-action-card.js
@@ -107,7 +107,7 @@ function buildStandardPayload(block, payload) {
 
 async function buildBlockFromFragment($block) {
   const fragmentName = $block.querySelector('div').textContent.trim();
-  const section = await fetchPlainBlockFromFragment($block, `/express/fragments/quick-action-card/${fragmentName}`, 'quick-action-card');
+  const section = await fetchPlainBlockFromFragment(`/express/fragments/quick-action-card/${fragmentName}`, 'quick-action-card');
   if (!section) {
     return false;
   }

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1688,7 +1688,7 @@ export function normalizeHeadings(block, allowedHeadings) {
   });
 }
 
-export async function fetchPlainBlockFromFragment($block, url, blockName) {
+export async function fetchPlainBlockFromFragment(url, blockName) {
   const location = new URL(window.location);
   const locale = getLocale(location);
   let fragmentUrl;
@@ -1701,7 +1701,7 @@ export async function fetchPlainBlockFromFragment($block, url, blockName) {
   const path = new URL(fragmentUrl).pathname.split('.')[0];
   const resp = await fetch(`${path}.plain.html`);
   if (resp.status === 404) {
-    $block.parentElement.parentElement.remove();
+    return null;
   } else {
     const html = await resp.text();
     const section = createTag('div');
@@ -1718,7 +1718,6 @@ export async function fetchPlainBlockFromFragment($block, url, blockName) {
     }
     return section;
   }
-  return null;
 }
 
 export async function fetchFloatingCta(path) {


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Hotfix no ticket

**Description**
 - Update fetchPlainBlockFromFragment function to not need block param anymore.
 - Internalize block replacement inside plans comparison block

**Test URLs:**
- Before: https://main--express-website--adobe.hlx.page/express/create/banner?lighthouse=on
- After: https://fragment-fetch-fix--express-website--webistry-development.hlx.page/express/create/banner?lighthouse=on
- Regression check (for quick-action-card): https://fragment-fetch-fix--express-website--webistry-development.hlx.page/express/feature/image/remove-background?lighthouse=on
