### PR TITLE
feat: instrument images coming from the content platform

### DIFF
--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -695,6 +695,14 @@ loadScript(martechURL, () => {
       sparkButtonId = `${sparkButtonId}${textToName($a.innerText.trim())} ${index}`;
     }
 
+    let assetId;
+    let assetPath;
+    const asset = $a.querySelector('video,img');
+    if (asset) {
+      assetId = asset.currentSrc || asset.src;
+      assetPath = new URL(asset.currentSrc || asset.src).pathname;
+    }
+
     if (useAlloy) {
       _satellite.track('event', {
         xdm: {},
@@ -723,6 +731,10 @@ loadScript(martechURL, () => {
                   buttonId: sparkButtonId || '',
                   sendTimestamp: new Date().getTime(),
                 },
+              },
+              hemingway: {
+                assetId,
+                assetPath,
               },
             },
           },

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -711,6 +711,7 @@ loadScript(martechURL, () => {
 
     if (useAlloy) {
       _satellite.track('event', {
+        documentUnloading: true,
         xdm: {},
         data: {
           eventType: 'web.webinteraction.linkClicks',

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -1150,6 +1150,7 @@ loadScript(martechURL, () => {
         // track a new event
         if (useAlloy) {
           _satellite.track('event', {
+            xdm: {},
             data: {
               eventType: 'web.webinteraction.linkClicks',
               web: {

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -699,8 +699,14 @@ loadScript(martechURL, () => {
     let assetPath;
     const asset = $a.querySelector('video,img');
     if (asset) {
-      assetId = asset.currentSrc || asset.src;
-      assetPath = new URL(asset.currentSrc || asset.src).pathname;
+      const assetSource = asset.currentSrc || asset.src;
+      const matches = assetSource.match(/cdn\.cp\.adobe\.io.*\/rendition\/([0-9a-f-]+)|\/(media_[0-9a-f]+)/);
+      assetPath = new URL(assetSource).pathname;
+      if (matches) {
+        assetId = matches[1] || matches[2];
+      } else {
+        assetId = assetPath;
+      }
     }
 
     if (useAlloy) {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -120,15 +120,20 @@ function trackViewedAssetsInDataLayer(assetsSelector = 'img[src*="/media_"],img[
         viewAssetObserver.unobserve(el);
 
         // Get asset details
+        let assetId;
         let assetPath = el.href // the reference for an a/svg tag
           || el.currentSrc // the active source in a picture/video/audio element
           || el.src; // the source for an image/video/iframe
         assetPath = new URL(assetPath).pathname;
-        const match = assetPath.match(/media_([a-f0-9]+)\.\w+/);
-        const assetFilename = match ? match[0] : assetPath;
+        const matches = assetPath.match(/cdn\.cp\.adobe\.io.*\/rendition\/([0-9a-f-]+)|\/(media_[0-9a-f]+)/);
+        if (matches) {
+          assetId = matches[1] || matches[2];
+        } else {
+          assetId = assetPath;
+        }
         const details = {
           event: 'viewasset',
-          assetId: assetFilename,
+          assetId,
           assetPath,
         };
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -124,8 +124,8 @@ function trackViewedAssetsInDataLayer(assetsSelector = 'img[src*="/media_"],img[
         let assetPath = el.href // the reference for an a/svg tag
           || el.currentSrc // the active source in a picture/video/audio element
           || el.src; // the source for an image/video/iframe
-        assetPath = new URL(assetPath).pathname;
         const matches = assetPath.match(/cdn\.cp\.adobe\.io.*\/rendition\/([0-9a-f-]+)|\/(media_[0-9a-f]+)/);
+        assetPath = new URL(assetPath).pathname;
         if (matches) {
           assetId = matches[1] || matches[2];
         } else {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -107,7 +107,7 @@ document.addEventListener('click', () => sampleRUM('click'));
  * Track assets in that appear in the viewport and add populate
  * `viewasset` events to the data layer.
  */
-function trackViewedAssetsInDataLayer(assetsSelector = 'img[src*="/media_"]') {
+function trackViewedAssetsInDataLayer(assetsSelector = 'img[src*="/media_"],img[src^="https://cdn.cp.adobe.io"]') {
   window.dataLayer = window.dataLayer || [];
 
   const viewAssetObserver = new IntersectionObserver((entries) => {


### PR DESCRIPTION
As part of the Condor initiative, we need to properly track images coming from the content platform as well.

Fix <jira-issue-id>

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/templates/flyer
- After: https://condor-image-views--express-website--adobe.hlx.page/express/templates/flyer
