### PR TITLE
feat(breadcrumbs-templates): Extracted short-title

### DIFF
--- a/express/scripts/templates.js
+++ b/express/scripts/templates.js
@@ -277,9 +277,9 @@ async function updateBlocks(data) {
   const linkList = document.querySelector('.link-list.fullwidth');
   const templateList = document.querySelector('.template-list.fullwidth.apipowered');
   const seoNav = document.querySelector('.seo-nav');
-  const shortTitle = createTag('meta', { name: 'short-title', content: data.shortTitle });
 
-  if (shortTitle) {
+  if (data.shortTitle) {
+    const shortTitle = createTag('meta', { name: 'short-title', content: data.shortTitle });
     const $head = document.querySelector('head');
     $head.append(shortTitle);
   }

--- a/express/scripts/templates.js
+++ b/express/scripts/templates.js
@@ -277,6 +277,12 @@ async function updateBlocks(data) {
   const linkList = document.querySelector('.link-list.fullwidth');
   const templateList = document.querySelector('.template-list.fullwidth.apipowered');
   const seoNav = document.querySelector('.seo-nav');
+  const shortTitle = createTag('meta', { name: 'short-title', content: data.shortTitle });
+
+  if (shortTitle) {
+    const $head = document.querySelector('head');
+    $head.append(shortTitle);
+  }
 
   if (heroAnimation) {
     if (data.heroAnimationTitle) {


### PR DESCRIPTION
Fix: https://jira.corp.adobe.com/browse/MWPW-122517

As the metadata is stored in the [metadata](https://adobe.sharepoint.com/:x:/r/sites/CC-Express/_layouts/15/Doc.aspx?sourcedoc=%7BFE02F0B2-26AC-46D1-A433-795157A3B92F%7D&file=metadata.xlsx&action=default&mobileredirect=true&cid=8d4ebe03-26c2-4094-806c-bdcc718b7769) for templates pages, it was not being added to the breadcrumbs. This fix extracts the 'short-title' from the metadata sheet and adds it into the metadata of the page.

Test URLs:
- Before: https://main--express-website--webistry-development.hlx.page/express/templates/flyer/christmas?lighthouse=on
- After: https://breadcrumbs-templates--express-website--webistry-development.hlx.page/express/templates/flyer/christmas?lighthouse=on

