### PR TITLE
[No Ticket]: fix url prefix for localized search pages

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -497,7 +497,7 @@ async function redirectSearch($searchBar) {
   const urlPrefix = locale === 'us' ? '' : `/${locale}`;
   const topicUrl = searchInput ? `/${searchInput}` : '';
   const taskUrl = `/${handlelize(currentTasks.toLowerCase())}`;
-  const searchUrlTemplate = `${urlPrefix}/express/templates/search?tasks=${currentTasks}&phformat=${format}&topics=${searchInput || "''"}`;
+  const searchUrlTemplate = `/express/templates/search?tasks=${currentTasks}&phformat=${format}&topics=${searchInput || "''"}`;
   const targetPath = `${urlPrefix}/express/templates${taskUrl}${topicUrl}`;
   const searchUrl = `${window.location.origin}${urlPrefix}${searchUrlTemplate}`;
   const pathMatch = (e) => e.path === targetPath;


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):


**Description:**
No ticket. This is to fix a small bug noticed during the working session with the localization team.
To test: go to the before and after page, and make any search using the search bar. The before should land on a 404 while the after should give you a search page

**Test URLs:**
- Before: https://main--express-website--adobe.hlx.page/br/express/templates/flyer?lighthouse=on
- After: https://search-locale-fix--express-website--webistry-development.hlx.page/br/express/templates/flyer?lighthouse=on
