### PR TITLE
[HOTFIX] Floating CTA: remove default reference on autoBlock building

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1825,9 +1825,7 @@ async function buildAutoBlocks($main) {
 
         desktopButton = buildBlock(buttonTypes.desktop, 'desktop');
         mobileButton = buildBlock(buttonTypes.mobile, 'mobile');
-      }
 
-      if (floatingCTAData) {
         [desktopButton, mobileButton].forEach((button) => {
           button.classList.add('spreadsheet-powered');
           if ($lastDiv) {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1814,24 +1814,20 @@ async function buildAutoBlocks($main) {
   if (['yes', 'true', 'on'].includes(getMetadata('show-floating-cta').toLowerCase()) || ['yes', 'true', 'on'].includes(getMetadata('show-multifunction-button').toLowerCase())) {
     if (!window.floatingCtasLoaded) {
       const floatingCTAData = await fetchFloatingCta(window.location.pathname);
-      const defaultButton = await fetchFloatingCta('default');
       let desktopButton;
       let mobileButton;
 
       if (floatingCTAData) {
         const buttonTypes = {
-          desktop: floatingCTAData.desktop || defaultButton.desktop,
-          mobile: floatingCTAData.mobile || defaultButton.mobile,
+          desktop: floatingCTAData.desktop,
+          mobile: floatingCTAData.mobile,
         };
 
         desktopButton = buildBlock(buttonTypes.desktop, 'desktop');
         mobileButton = buildBlock(buttonTypes.mobile, 'mobile');
-      } else if (defaultButton) {
-        desktopButton = buildBlock(defaultButton.desktop, 'desktop');
-        mobileButton = buildBlock(defaultButton.mobile, 'mobile');
       }
 
-      if (floatingCTAData || defaultButton) {
+      if (floatingCTAData) {
         [desktopButton, mobileButton].forEach((button) => {
           button.classList.add('spreadsheet-powered');
           if ($lastDiv) {


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

**Description**
no ticket. Tweaking the live column behavior to authors' preference -- no button rendered instead of rendering a default one if live column is 'N'.

Test note: This actually cannot be tested on staging link as the live=N guard only works on prod.

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/create/instagram-story?dev=on&lighthouse=on
- After: https://fcta-n-fix--express-website--webistry-development.hlx.page/express/create/instagram-story?dev=on&lighthouse=on
