### PR TITLE
[MWPW-129203] Blocks Unhandled Errors Fallback Behavior

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1063,6 +1063,7 @@ export async function loadBlock(block, eager = false) {
               await mod.default(block, blockName, document, eager);
             }
           } catch (err) {
+            block.remove();
             // eslint-disable-next-line no-console
             console.log(`failed to load module for ${blockName}`, err);
           }


### PR DESCRIPTION
Fix <https://jira.corp.adobe.com/browse/MWPW-129203>

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/
- After: https://block-fallback--express-website--adobe.hlx.page/express/?lighthouse=on

As of now, the behaviors of unhandled errors thrown in each individual blocks are totally up to each bock's implementation. Namely, if the content is not removed from the DOM before an error happens, those content could be living in the page and noticeable by end users. For a block that has many and big raw content/images, it could look very messy when unexpected errors happen.

As a quick solution, we can just remove the block from the page in error handling for now. But I want some feedbacks as in whether or not it is necessary in this project to show a Fallback block when not in prod, and whether we want to add an extra `data-block-status` like `failed` (now we only have `initialized`, `loading`, and `loaded`) for tracking.