### PR TITLE
MWPW-129831 - Franklin experimentation link tracking issue

### DIFF
--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -510,6 +510,7 @@ loadScript(martechURL, () => {
   }
 
   function trackButtonClick($a) {
+    console.log('click tracked for ', $a);
     let adobeEventName = 'adobe.com:express:cta:';
     let sparkEventName;
     let sparkButtonId;
@@ -768,10 +769,10 @@ loadScript(martechURL, () => {
     trackBranchParameters($links);
 
     // for tracking all of the links
-    $links.forEach(($a) => {
-      $a.addEventListener('click', () => {
-        trackButtonClick($a);
-      });
+    d.addEventListener('click', (event) => {
+      if (event.target.tagName === 'A') {
+        trackButtonClick(event.target);
+      }
     });
 
     // for tracking the faq

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -510,7 +510,6 @@ loadScript(martechURL, () => {
   }
 
   function trackButtonClick($a) {
-    console.log('click tracked for ', $a);
     let adobeEventName = 'adobe.com:express:cta:';
     let sparkEventName;
     let sparkButtonId;


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix [MWPW-129831](https://jira.corp.adobe.com/browse/MWPW-129831)

**Problem & Solution**
Current instrumentation logic, is finding the links from the existing DOM and attaching the `trackButtonClick` event listener for the links. Sometimes, when the experiment is running, the DOM Is loaded after the event listeners are attached in the instrument.js, so these links are missing the tracking. As a fix, changed the listening on the document and call `trackButtonClick` if the `event.target` is anchor tag

Test URLs:
https://mwpw-129831--express-website--adobe.hlx.page/express/create/poster