### PR TITLE
Homepage v3 toggle width

### DIFF
--- a/express/blocks/intent-toggle-desktop/intent-toggle-desktop.js
+++ b/express/blocks/intent-toggle-desktop/intent-toggle-desktop.js
@@ -52,6 +52,7 @@ function initButton(block, sections, index) {
 
       const firstButtonWidthGrabbed = () => {
         if (buttons[index].offsetWidth > 0 && buttons[index].textContent !== '') {
+          console.log(buttons[index].offsetWidth);
           toggleBackground.style.width = `${buttons[index].offsetWidth + 5}px`;
           toggleBackground.style.left = 0;
           buttons[index].classList.add('active');

--- a/express/blocks/intent-toggle-desktop/intent-toggle-desktop.js
+++ b/express/blocks/intent-toggle-desktop/intent-toggle-desktop.js
@@ -51,14 +51,28 @@ function initButton(block, sections, index) {
       toggleBackground.classList.add('loading');
 
       const firstButtonWidthGrabbed = () => {
+        function getContentWidth (element) {
+          var styles = getComputedStyle(element)
+          return element.clientWidth
+            - parseFloat(styles.paddingLeft)
+            - parseFloat(styles.paddingRight);
+        }
+
         if (buttons[index].offsetWidth > 0 && buttons[index].textContent !== '') {
-          console.log(buttons[index].offsetWidth);
+          const button = buttons[index];
+          const styles = getComputedStyle(button);
+          console.log(styles);
+          console.log(styles.paddingLeft, styles.paddingRight);
+          console.log(button.offsetWidth);
           toggleBackground.style.width = `${buttons[index].offsetWidth + 5}px`;
           toggleBackground.style.left = 0;
           buttons[index].classList.add('active');
           toggleBackground.classList.remove('loading');
         } else {
-          requestAnimationFrame(firstButtonWidthGrabbed);
+          console.log('Calling again!');
+          setTimeout(() => {
+            requestAnimationFrame(firstButtonWidthGrabbed);
+          }, 100);
         }
       };
 

--- a/express/blocks/intent-toggle-desktop/intent-toggle-desktop.js
+++ b/express/blocks/intent-toggle-desktop/intent-toggle-desktop.js
@@ -49,44 +49,16 @@ function initButton(block, sections, index) {
 
     if (index === 0) {
       toggleBackground.classList.add('loading');
-
-      const firstButtonWidthGrabbed = () => {
-        function getContentWidth (element) {
-          var styles = getComputedStyle(element)
-          return element.clientWidth
-            - parseFloat(styles.paddingLeft)
-            - parseFloat(styles.paddingRight);
-        }
-
-        if (buttons[index].offsetWidth > 0 && buttons[index].textContent !== '') {
-          const button = buttons[index];
-          const styles = getComputedStyle(button);
-          console.log(styles);
-          console.log(styles.paddingLeft, styles.paddingRight);
-          console.log(button.offsetWidth);
+      const firstButtonWidthGrabbed = setInterval(() => {
+        // Set width threshold to 72, as it was triggering in Safari on a half-formed button
+        if (buttons[index].offsetWidth > 72 && buttons[index].textContent !== '') {
           toggleBackground.style.width = `${buttons[index].offsetWidth + 5}px`;
           toggleBackground.style.left = 0;
-          buttons[index].classList.add('active');
-          toggleBackground.classList.remove('loading');
-        } else {
-          console.log('Calling again!');
-          setTimeout(() => {
-            requestAnimationFrame(firstButtonWidthGrabbed);
-          }, 100);
+          clearInterval(firstButtonWidthGrabbed);
         }
-      };
-
-      requestAnimationFrame(firstButtonWidthGrabbed);
-
-      // const firstButtonWidthGrabbed = setInterval(() => {
-      //   if (buttons[index].offsetWidth > 0 && buttons[index].textContent !== '') {
-      //     toggleBackground.style.width = `${buttons[index].offsetWidth + 5}px`;
-      //     toggleBackground.style.left = 0;
-      //     clearInterval(firstButtonWidthGrabbed);
-      //   }
-      //   buttons[index].classList.add('active');
-      //   toggleBackground.classList.remove('loading');
-      // }, 200);
+        buttons[index].classList.add('active');
+        toggleBackground.classList.remove('loading');
+      }, 200);
 
       // initializing the page with first tab sections
       toggleSections(sections, buttons, index);

--- a/express/blocks/intent-toggle-desktop/intent-toggle-desktop.js
+++ b/express/blocks/intent-toggle-desktop/intent-toggle-desktop.js
@@ -49,15 +49,29 @@ function initButton(block, sections, index) {
 
     if (index === 0) {
       toggleBackground.classList.add('loading');
-      const firstButtonWidthGrabbed = setInterval(() => {
-        if (buttons[index].offsetWidth > 0) {
+
+      const firstButtonWidthGrabbed = () => {
+        if (buttons[index].offsetWidth > 0 && buttons[index].textContent !== '') {
           toggleBackground.style.width = `${buttons[index].offsetWidth + 5}px`;
           toggleBackground.style.left = 0;
-          clearInterval(firstButtonWidthGrabbed);
+          buttons[index].classList.add('active');
+          toggleBackground.classList.remove('loading');
+        } else {
+          requestAnimationFrame();
         }
-        buttons[index].classList.add('active');
-        toggleBackground.classList.remove('loading');
-      }, 200);
+      };
+
+      requestAnimationFrame(firstButtonWidthGrabbed);
+
+      // const firstButtonWidthGrabbed = setInterval(() => {
+      //   if (buttons[index].offsetWidth > 0 && buttons[index].textContent !== '') {
+      //     toggleBackground.style.width = `${buttons[index].offsetWidth + 5}px`;
+      //     toggleBackground.style.left = 0;
+      //     clearInterval(firstButtonWidthGrabbed);
+      //   }
+      //   buttons[index].classList.add('active');
+      //   toggleBackground.classList.remove('loading');
+      // }, 200);
 
       // initializing the page with first tab sections
       toggleSections(sections, buttons, index);

--- a/express/blocks/intent-toggle-desktop/intent-toggle-desktop.js
+++ b/express/blocks/intent-toggle-desktop/intent-toggle-desktop.js
@@ -58,7 +58,7 @@ function initButton(block, sections, index) {
           buttons[index].classList.add('active');
           toggleBackground.classList.remove('loading');
         } else {
-          requestAnimationFrame();
+          requestAnimationFrame(firstButtonWidthGrabbed);
         }
       };
 


### PR DESCRIPTION
Fix: https://jira.corp.adobe.com/browse/MWPW-123032

Test URLs:
- Before: https://homepage-v3--express-website--adobe.hlx.page/drafts/qiyundai/intent-toggle/draft
- After: https://homepage-v3-toggle-width--express-website--webistry-development.hlx.page/drafts/qiyundai/intent-toggle/draft

Increased the threshold for checking if the intent-toggle-button has been loaded from 0 up to 72px. 72px is the padding that applied on the button, I had noticed that when the glitch occurred, it was triggering with only 6px of padding on each side, so this will ensure button has fully loaded including padding.
