### PR TITLE
feat(debounce-throttle-memoize): utils.js

### DIFF
--- a/express/scripts/utils.js
+++ b/express/scripts/utils.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export function debounce(cb, time, { leading = false } = {}) {
+  let timer = null;
+  return function debounced(...args) {
+    let invoked = false;
+    if (timer === null && leading) {
+      cb.apply(this, args);
+      invoked = true;
+    }
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      if (!invoked) {
+        cb.apply(this, args);
+      }
+      timer = null;
+    }, time);
+  };
+}
+
+export function throttle(cb, delay, { trailing = false } = {}) {
+  let timer = null;
+  let lastArgs = null;
+  function tryToEnd() {
+    if (lastArgs && trailing) {
+      cb.apply(this, lastArgs);
+      lastArgs = null;
+      timer = setTimeout(tryToEnd.bind(this), delay);
+    } else {
+      timer = null;
+    }
+  }
+  return function throttled(...args) {
+    if (timer) {
+      lastArgs = args;
+      return;
+    }
+    cb.apply(this, args);
+    timer = setTimeout(tryToEnd.bind(this), delay);
+  };
+}
+
+// returned memoized function is async/sync if input cb is async/sync respectively
+export function memoize(cb, { key = (...args) => args.join(','), ttl } = {}) {
+  if (cb && !(cb instanceof Function)) throw new Error('cb must be a function');
+  if (!(ttl > 0 && Number.isInteger(ttl))) throw new Error('ttl must be greater than 0');
+  const cache = new Map();
+  const timers = new Map();
+  function invalidate(k) {
+    cache.delete(k);
+    timers.delete(k);
+  }
+  return function memoized(...args) {
+    const k = key(...args);
+    if (cache.has(k)) {
+      if (ttl) {
+        clearTimeout(timers.get(k));
+        timers.set(
+          k,
+          setTimeout(() => {
+            invalidate(k);
+          }, ttl),
+        );
+      }
+      return cache.get(k);
+    }
+    try {
+      const result = cb.apply(this, args);
+      if (result && typeof result.then === 'function') {
+        result.catch(() => {
+          invalidate(k);
+        });
+      }
+      cache.set(k, result);
+      if (ttl) {
+        timers.set(
+          k,
+          setTimeout(() => {
+            invalidate(k);
+          }, ttl),
+        );
+      }
+      return result;
+    } catch (e) {
+      console.error('Memoized Callback Error: ', e);
+      throw e;
+    }
+  };
+}

--- a/test/unit/scripts/utils.test.js
+++ b/test/unit/scripts/utils.test.js
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* global expect */
+/* eslint-disable no-unused-expressions */
+/* eslint-env mocha */
+
+import { throttle, debounce, memoize } from '../../../express/scripts/utils.js';
+
+describe('Throttle', () => {
+  it('should throttle a function', () => {
+    const arr = [];
+    const fn = throttle(() => {
+      arr.push(1);
+    }, 100);
+    fn();
+    fn();
+    fn();
+    expect(arr.length).to.equal(0 + 1);
+  });
+  it('should throttle a function with trailing', async () => {
+    const arr = [];
+    const fn = throttle(
+      () => {
+        arr.push(1);
+      },
+      100,
+      { trailing: true },
+    );
+    fn();
+    fn();
+    fn();
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(arr.length).to.equal(0 + 1 + 1);
+  });
+
+  it('should invoke with the latest arg', async () => {
+    const arr = [];
+    const fn = throttle((a) => {
+      arr.push(a);
+    }, 100);
+    fn(1);
+    fn(2);
+    fn(3);
+    fn(4);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(arr.length).to.equal(0 + 1);
+    expect(arr[arr.length - 1]).to.equal(1);
+
+    arr.splice(0, arr.length);
+    const fnTrailing = throttle(
+      (a) => {
+        arr.push(a);
+      },
+      100,
+      { trailing: true },
+    );
+    fnTrailing(1);
+    fnTrailing(2);
+    fnTrailing(3);
+    fnTrailing(4);
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(arr.length).to.equal(0 + 1 + 1);
+    expect(arr[arr.length - 1]).to.equal(4);
+  });
+
+  it('should maintain binding of this', async () => {
+    const obj = {
+      arr: [],
+      fn() {
+        this.arr.push(1);
+      },
+      throttledInside: throttle(function f() {
+        this.arr.push(1);
+      }),
+    };
+    const fn = throttle(obj.fn, 100).bind(obj);
+    fn();
+    fn();
+    fn();
+    fn();
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(obj.arr.length).to.equal(0 + 1);
+
+    obj.arr.splice(0, obj.arr.length);
+    obj.throttledInside();
+    obj.throttledInside();
+    obj.throttledInside();
+    obj.throttledInside();
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(obj.arr.length).to.equal(0 + 1);
+
+    obj.arr.splice(0, obj.arr.length);
+    const fnNoTrailing = throttle(obj.fn, 100, { trailing: true }).bind(obj);
+    fnNoTrailing();
+    fnNoTrailing();
+    fnNoTrailing();
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(obj.arr.length).to.equal(0 + 1 + 1);
+  });
+});
+
+describe('Debounce', () => {
+  it('should debounce a function', async () => {
+    const arr = [];
+    const fn = debounce(() => {
+      arr.push(1);
+    }, 100);
+    fn();
+    fn();
+    fn();
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(arr.length).to.equal(0 + 1);
+  });
+
+  it('should debounce but invoke immediately with leading', async () => {
+    const arr = [];
+    const fn = debounce(() => {
+      arr.push(1);
+    }, 100, { leading: true });
+    fn();
+    fn();
+    fn();
+    fn();
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(arr.length).to.equal(0 + 1 + 1);
+  });
+
+  it('should invoke with latest args', async () => {
+    const arr = [];
+    const fn = debounce((a) => {
+      arr.push(a);
+    }, 100);
+    fn(1);
+    fn(2);
+    fn(3);
+    fn(4);
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(arr.length).to.equal(0 + 1);
+    expect(arr[arr.length - 1]).to.equal(4);
+
+    arr.splice(0, arr.length);
+
+    const fnLeading = debounce((a) => {
+      arr.push(a);
+    }, 100, { leading: true });
+    fnLeading(10);
+    fnLeading(2);
+    fnLeading(3);
+    fnLeading(4);
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(arr.length).to.equal(0 + 1 + 1);
+    expect(arr[0]).to.equal(10);
+    expect(arr[arr.length - 1]).to.equal(4);
+  });
+
+  it('should maintain binding of this', async () => {
+    const obj = {
+      arr: [],
+      fn() {
+        this.arr.push(1);
+      },
+      debouncedInside: debounce(function f() {
+        this.arr.push(1);
+      }),
+    };
+    const fn = debounce(obj.fn, 100).bind(obj);
+    fn();
+    fn();
+    fn();
+    fn();
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(obj.arr.length).to.equal(0 + 1);
+
+    obj.arr.splice(0, obj.arr.length);
+    obj.debouncedInside();
+    obj.debouncedInside();
+    obj.debouncedInside();
+    obj.debouncedInside();
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(obj.arr.length).to.equal(0 + 1);
+  });
+});
+
+describe('Memoize', () => {
+  let invoked = 0;
+  beforeEach(() => {
+    invoked = 0;
+  });
+  const fn = (a, b) => {
+    invoked += 1;
+    return a + b;
+  };
+  const fnAsync = async (a, b) => {
+    invoked += 1;
+    return a + b;
+  };
+  it('should throw with invalid cb', () => {
+    expect(() => memoize(5)).to.throw();
+  });
+  it('should throw with invalid ttl', () => {
+    expect(() => memoize(0)).to.throw();
+    expect(() => memoize(-1)).to.throw();
+    expect(() => memoize(NaN)).to.throw();
+  });
+  it('should memoize a function', () => {
+    const memoized = memoize(fn, { ttl: 1000 });
+    expect(typeof memoized).to.equal('function');
+    expect(memoized(1, 2)).to.equal(3);
+    expect(memoized(1, 2)).to.equal(3);
+    expect(invoked).to.equal(1);
+    expect(memoized(2, 2)).to.equal(4);
+    expect(invoked).to.equal(2);
+    expect(memoized(1, 2)).to.equal(3);
+    expect(invoked).to.equal(2);
+  });
+  it('should memoize an async function', async () => {
+    const memoized = memoize(fnAsync, { ttl: 1000 });
+    expect(typeof memoized).to.equal('function');
+    await memoized(1, 2).then((res) => {
+      expect(res).to.equal(3);
+    });
+    await memoized(1, 2).then((res) => {
+      expect(res).to.equal(3);
+    });
+    expect(invoked).to.equal(1);
+    await memoized(2, 2).then((res) => {
+      expect(res).to.equal(4);
+    });
+    expect(invoked).to.equal(2);
+    await memoized(1, 2).then((res) => {
+      expect(res).to.equal(3);
+    });
+    expect(invoked).to.equal(2);
+  });
+  it('should memoize a function with ttl', () => {
+    const memoized = memoize(fn, { ttl: 500 });
+    expect(typeof memoized).to.equal('function');
+    expect(memoized(1, 2)).to.equal(3);
+    expect(invoked).to.equal(1);
+    setTimeout(() => {
+      expect(memoized(1, 2)).to.equal(3);
+      expect(invoked).to.equal(2);
+    }, 700);
+    setTimeout(() => {
+      expect(memoized(1, 2)).to.equal(3);
+      expect(invoked).to.equal(1);
+    }, 100);
+    expect(memoized(1, 2)).to.equal(3);
+    expect(invoked).to.equal(1);
+  });
+  it('should memoize an async function with ttl', async () => {
+    const memoized = memoize(fnAsync, { ttl: 500 });
+    expect(typeof memoized).to.equal('function');
+    await memoized(1, 2).then((res) => {
+      expect(res).to.equal(3);
+    });
+    expect(invoked).to.equal(1);
+    setTimeout(() => {
+      memoized(1, 2).then((res) => {
+        expect(res).to.equal(3);
+        expect(invoked).to.equal(2);
+      });
+    }, 700);
+    setTimeout(() => {
+      memoized(1, 2).then(() => {
+        expect(invoked).to.equal(1);
+      });
+    }, 100);
+    await memoized(1, 2);
+    expect(invoked).to.equal(1);
+  });
+
+  it('should throw on sync error', () => {
+    const memoized = memoize(() => {
+      invoked += 1;
+      throw new Error('test');
+    }, { ttl: 500 });
+    expect(() => memoized()).to.throw();
+    expect(invoked).to.equal(1);
+    expect(() => memoized()).to.throw();
+    expect(invoked).to.equal(2);
+  });
+
+  it('should invalidate cache on error async', async () => {
+    const memoized = memoize(async () => {
+      invoked += 1;
+      throw new Error('test');
+    }, { ttl: 500 });
+    await memoized().catch(() => {});
+    await memoized().catch(() => {});
+    await memoized().catch(() => {});
+    await memoized().catch(() => {});
+    expect(invoked).to.equal(4);
+  });
+});


### PR DESCRIPTION
Fix [MWPW-130160](https://jira.corp.adobe.com/browse/MWPW-130160)

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/
- After: https://debounce-throttle-memoize--express-website--adobe.hlx.page/express/

**A benign PR that creates utils.js and fill it with util functions and unit tests. Util functions like debounce, throttle, and memoize are needed and used for implementing Autocomplete [here](https://github.com/adobe/express-website/commit/48b200d28ba4006522637fe7e49a28c0a80d81ae#diff-97eb231bc102882b26ebf76f1e9088b590dcb63ff5b9de6744186b4e6897601d). Once this is merged, I'll update that branch and rebase on main.**

- If you folks prefer, I can also split them into 3 separate files.
- In the future efforts of reducing the size of scripts.js, we can move more functions from scripts.js into utils.js. Since scripts.js blocks everything for every page, we should make sure only functions that are needed for all page can live in scripts.js. Other shared functions should go into utils.js.