### PR TITLE
[HOTFIX]: Template List -  language specific results fix 3

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -73,6 +73,7 @@ async function populateHeadingPlaceholder(locale) {
   const camelHeading = heading === 'Adobe Express' ? heading : heading.charAt(0).toLowerCase() + heading.slice(1);
   const placeholders = await fetchPlaceholders();
   const lang = getLanguage(getLocale(window.location));
+  const templateCount = lang === 'es-ES' ? props.total.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ') : props.total.toLocaleString(lang);
   let grammarTemplate;
 
   if (getMetadata('template-search-page') === 'Y') {
@@ -83,7 +84,7 @@ async function populateHeadingPlaceholder(locale) {
 
   if (grammarTemplate) {
     grammarTemplate = grammarTemplate
-      .replace('{{quantity}}', props.total.toLocaleString(lang))
+      .replace('{{quantity}}', templateCount)
       .replace('{{Type}}', heading)
       .replace('{{type}}', camelHeading);
 


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

**Description**
No ticket. The ES template-list results are showing the total count in old thousand separator format. Using space instead as a special treatment for now.

**Test URLs:**
- Before: https://main--express-website--adobe.hlx.page/express/templates/?lighthouse=on
- After: https://es-number-fix--express-website--wbstry.hlx.page/express/templates/?lighthouse=on
