### PR TITLE
[MWPW 129072] Broken href on buttons

### DIFF
--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -38,7 +38,7 @@ function transformToVideoColumn($cell, $a) {
       $button.closest('.button-container').remove();
     }
   });
-  $a.setAttribute('rel', 'nofollow')
+  $a.setAttribute('rel', 'nofollow');
 
   $cell.classList.add('column-video');
   $parent.classList.add('columns-video');

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -38,6 +38,7 @@ function transformToVideoColumn($cell, $a) {
       $button.closest('.button-container').remove();
     }
   });
+  $a.setAttribute('rel', 'nofollow')
 
   $cell.classList.add('column-video');
   $parent.classList.add('columns-video');
@@ -188,7 +189,6 @@ export default function decorate($block) {
             linkImage($cell);
           }
         }
-        $a.href = '';
       }
       if ($a && $a.classList.contains('button')) {
         if ($block.className.includes('fullsize')) {

--- a/express/blocks/columns/columns.js
+++ b/express/blocks/columns/columns.js
@@ -188,6 +188,7 @@ export default function decorate($block) {
             linkImage($cell);
           }
         }
+        $a.href = '';
       }
       if ($a && $a.classList.contains('button')) {
         if ($block.className.includes('fullsize')) {

--- a/express/blocks/hero-animation/hero-animation.js
+++ b/express/blocks/hero-animation/hero-animation.js
@@ -109,6 +109,7 @@ function transformToVideoLink($cell, $a) {
   $a.addEventListener('click', (e) => {
     e.preventDefault();
   });
+  $a.setAttribute('rel', 'nofollow');
   const title = $a.textContent.trim();
   // gather video urls from all links in cell
   const vidUrls = [];
@@ -126,7 +127,6 @@ function transformToVideoLink($cell, $a) {
         }
       }
     });
-  $a.href = '';
   $a.addEventListener('click', (e) => {
     e.preventDefault();
     displayVideoModal(vidUrls, title, true);

--- a/express/blocks/hero-animation/hero-animation.js
+++ b/express/blocks/hero-animation/hero-animation.js
@@ -126,7 +126,7 @@ function transformToVideoLink($cell, $a) {
         }
       }
     });
-
+  $a.href = '';
   $a.addEventListener('click', (e) => {
     e.preventDefault();
     displayVideoModal(vidUrls, title, true);


### PR DESCRIPTION
Fix: https://jira.corp.adobe.com/browse/MWPW-129072

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/nonprofits
- After: https://mwpw-129072--express-website--wbstry.hlx.page/express/nonprofits?lighthouse=on

The 'Watch Video/Now' buttons on the page contained an href which was returning a 404 error to Google Search. Added a 'no-follow' attribute to the a tags. Sharon will let us know once this is merged if it fixes the issues she is seeing from the SEO side. 
