### PR TITLE
fix: race condition between instrument.js and ccl-quick-action rendering

### DIFF
--- a/express/experiments/ccx0027a/blocks/quick-action2/quick-action.js
+++ b/express/experiments/ccx0027a/blocks/quick-action2/quick-action.js
@@ -186,4 +186,7 @@ export default async function decorate(block) {
   }
   addLottieIcons(document.querySelectorAll('a.button.upload-your-photo'), 'arrow-up');
   addListenersOnMockElements(mockQuickActionEle);
+  // trigger the quick-action-rendered event
+  const quickActionRenderedEvent = new Event('ccl-quick-action-rendered');
+  document.querySelector(ELEMENT_NAME).dispatchEvent(quickActionRenderedEvent);
 }

--- a/express/scripts/instrument.js
+++ b/express/scripts/instrument.js
@@ -615,6 +615,9 @@ loadScript(martechURL, () => {
         sparkEventName = 'landing:ctaPressed';
       }
     // quick actions clicks
+    } else if ($a.closest('ccl-quick-action') && $a.classList.contains('upload-your-photo')) {
+      // this event is handled at mock-file-input level
+      return;
     } else if ($a.href && ($a.href.match(/spark\.adobe\.com\/[a-zA-Z-]*\/?tools/g) || $a.href.match(/express\.adobe\.com\/[a-zA-Z-]*\/?tools/g))) {
       adobeEventName = appendLinkText(adobeEventName, $a);
       sparkEventName = 'quickAction:ctaPressed';
@@ -781,11 +784,11 @@ loadScript(martechURL, () => {
       });
     }
   }
-  const cclQuickAction = d.getElementsByTagName('ccl-quick-action');
-  if (cclQuickAction.length) {
+
+  function handleQuickActionEvents(el) {
     let frictionLessQuctionActionsTrackingEnabled = false;
     sendEventToAdobeAnaltics('quickAction:uploadPageViewed');
-    cclQuickAction[0].addEventListener('ccl-quick-action-complete', () => {
+    el[0].addEventListener('ccl-quick-action-complete', () => {
       if (frictionLessQuctionActionsTrackingEnabled) {
         return;
       }
@@ -801,6 +804,18 @@ loadScript(martechURL, () => {
       frictionLessQuctionActionsTrackingEnabled = true;
     });
   }
+
+  const cclQuickAction = d.getElementsByTagName('ccl-quick-action');
+  if (cclQuickAction.length) {
+    handleQuickActionEvents(cclQuickAction);
+  } else {
+    d.addEventListener('ccl-quick-action-rendered', (e) => {
+      if (e.target.tagName === 'CCL-QUICK-ACTION') {
+        handleQuickActionEvents(d.getElementsByTagName('ccl-quick-action'));
+      }
+    });
+  }
+
   d.addEventListener('click', (e) => {
     if (e.target.id === 'mock-file-input') {
       sendEventToAdobeAnaltics('adobe.com:express:cta:uploadYourPhoto');


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Issue: when the ccl-quick-action rendering is delayed but instrument.js is loaded and executed, then `cclQuickAction.length` will be 0, so further events will not fire. To fix this, introduced a new event `ccl-quick-action-rendered`, if the rendering is already complete, then the existing flow will take care, otherwise, an event listener will be registered to handle the events async.

Fix quick action race condition


Test URLs:
https://quick-action-race-condition--express-website--adobe.hlx.page/express/spotlight/test/remove-background-new?experiment=ccx0027a%2Fchallenger-1