### PR TITLE
[BETA] Floating-CTA: Add suppression power to floating-cta sheet

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1843,6 +1843,7 @@ async function buildAutoBlocks($main) {
   if (['yes', 'true', 'on'].includes(getMetadata('show-floating-cta').toLowerCase()) || ['yes', 'true', 'on'].includes(getMetadata('show-multifunction-button').toLowerCase())) {
     if (!window.floatingCtasLoaded) {
       const floatingCTAData = await fetchFloatingCta(window.location.pathname);
+      const validButtonVersion = ['floating-button', 'multifunction-button', 'bubble-ui-button', 'floating-panel'];
       let desktopButton;
       let mobileButton;
 
@@ -1852,13 +1853,15 @@ async function buildAutoBlocks($main) {
           mobile: floatingCTAData.mobile,
         };
 
-        desktopButton = buildBlock(buttonTypes.desktop, 'desktop');
-        mobileButton = buildBlock(buttonTypes.mobile, 'mobile');
+        desktopButton = validButtonVersion.includes(buttonTypes.desktop) ? buildBlock(buttonTypes.desktop, 'desktop') : null;
+        mobileButton = validButtonVersion.includes(buttonTypes.mobile) ? buildBlock(buttonTypes.mobile, 'mobile') : null;
 
         [desktopButton, mobileButton].forEach((button) => {
-          button.classList.add('spreadsheet-powered');
-          if ($lastDiv) {
-            $lastDiv.append(button);
+          if (button) {
+            button.classList.add('spreadsheet-powered');
+            if ($lastDiv) {
+              $lastDiv.append(button);
+            }
           }
         });
       }


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

ticket to follow
**Description:**
Added the ability to suppress floating CTA for a certain audience using non-block words in the desktop/mobile column. (recommend something verbose. i.e. 'no-button', 'N/A')
As long as the name in the cell is not one of the valid version of the floating-cta, the button won't load for that url.

This sheet contains the 
https://adobe.sharepoint.com/:x:/r/sites/CC-Express/_layouts/15/Doc.aspx?sourcedoc=%7BFBD7F903-4C71-4BF5-AB07-E44143691889%7D&file=floating-cta-dev.xlsx&action=default&mobileredirect=true&cid=9193a015-081b-4f29-983a-df44ffb55be1 

**Test URLs:**
- Before: https://main--express-website--adobe.hlx.page/express/beta?lighthouse=on&dev=on
- After: https://split-floating-cta--express-website--wbstry.hlx.page/express/beta?lighthouse=on&dev=on
