### PR TITLE
Preparing for stage to main sync up without latest Beta Gnav changes

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -142,11 +142,11 @@ async function loadFEDS() {
   window.addEventListener('adobePrivacy:PrivacyReject', handleConsentSettings);
   window.addEventListener('adobePrivacy:PrivacyCustom', handleConsentSettings);
 
-  const isHomepage = window.location.pathname.endsWith('/express/') || window.location.pathname.endsWith('/express/beta');
+  const isHomepage = window.location.pathname.endsWith('/express/');
   const isMegaNav = window.location.pathname.startsWith('/express')
     || window.location.pathname.startsWith('/education');
   const fedsExp = isMegaNav
-    ? `adobe-express/ax-gnav${isHomepage ? '-homepage-beta' : '-beta'}`
+    ? `adobe-express/ax-gnav${isHomepage ? '-homepage' : ''}`
     : 'cc-express/cc-express-gnav';
 
   async function buildBreadCrumbArray() {


### PR DESCRIPTION
Preparing for stage to main sync up without latest Beta Gnav changes

Test URLs:
- Before: https://stage--express-website--adobe.hlx.page/express/
- After: https://stage-without-gnav--express-website--adobe.hlx.page/express/