### PR TITLE
Putting back beta gnav changes for launch preparation

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -142,11 +142,11 @@ async function loadFEDS() {
   window.addEventListener('adobePrivacy:PrivacyReject', handleConsentSettings);
   window.addEventListener('adobePrivacy:PrivacyCustom', handleConsentSettings);
 
-  const isHomepage = window.location.pathname.endsWith('/express/');
+  const isHomepage = window.location.pathname.endsWith('/express/') || window.location.pathname.endsWith('/express/beta');
   const isMegaNav = window.location.pathname.startsWith('/express')
     || window.location.pathname.startsWith('/education');
   const fedsExp = isMegaNav
-    ? `adobe-express/ax-gnav${isHomepage ? '-homepage' : ''}`
+    ? `adobe-express/ax-gnav${isHomepage ? '-homepage-beta' : '-beta'}`
     : 'cc-express/cc-express-gnav';
 
   async function buildBreadCrumbArray() {


### PR DESCRIPTION
Putting back beta gnav changes for launch preparation

Test URLs:
- Before: https://stage--express-website--adobe.hlx.page/express/
- After: https://stage-with-beta-gnav-back--express-website--adobe.hlx.page/express/
