### PR TITLE
suppress gnav breadcrumbs for templates

### DIFF
--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -159,30 +159,26 @@ async function loadFEDS() {
     );
 
     const placeholders = await fetchPlaceholders();
-    const validCategories = ['create', 'feature'];
-    const pathSegments = window.location.pathname.split('/')
-      .filter((element) => element !== '')
-      .filter((element) => element !== locale);
+    const validSecondPathSegments = ['create', 'feature'];
+    const pathSegments = window.location.pathname
+      .split('/')
+      .filter((e) => e !== locale);
     const localePath = locale === 'us' ? '' : `${locale}/`;
-    let category = pathSegments[1];
-    const secondPathSegment = category.toLowerCase();
-    const pagesShortNameElement = document.querySelector('meta[name="short-title"]');
-    const pagesShortName = pagesShortNameElement ? pagesShortNameElement.getAttribute('content') : null;
+    const secondPathSegment = pathSegments[1].toLowerCase();
+    const pagesShortNameElement = document.head.querySelector('meta[name="short-title"]');
+    const pagesShortName = pagesShortNameElement?.getAttribute('content') ?? null;
+    const replacedCategory = placeholders[`breadcrumbs-${secondPathSegment}`];
 
-    if ((!pagesShortName && pathSegments.length > 2)
-      || !placeholders[`breadcrumbs-${category}`]
+    if (!pagesShortName
+      || pathSegments.length <= 2
+      || !replacedCategory
+      || !validSecondPathSegments.includes(replacedCategory)
       || locale !== 'us') { // Remove this line once locale translations are complete
       return undefined;
     }
-    category = capitalize(placeholders[`breadcrumbs-${category}`]);
-    validCategories.push(category);
 
-    const secondBreadCrumb = buildBreadCrumb(secondPathSegment, category, `${localePath}/express`);
+    const secondBreadCrumb = buildBreadCrumb(secondPathSegment, capitalize(replacedCategory), `${localePath}/express`);
     const breadCrumbList = [secondBreadCrumb];
-
-    if (!validCategories.includes(category)) {
-      return undefined;
-    }
 
     if (pathSegments.length >= 3) {
       const thirdBreadCrumb = buildBreadCrumb(pagesShortName, pagesShortName, secondBreadCrumb.url);

--- a/express/scripts/gnav.js
+++ b/express/scripts/gnav.js
@@ -151,7 +151,7 @@ async function loadFEDS() {
 
   async function buildBreadCrumbArray() {
     if (isHomepage || getMetadata('hide-breadcrumbs') === 'true') {
-      return undefined;
+      return null;
     }
     const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
     const buildBreadCrumb = (path, name, parentPath = '') => (
@@ -174,7 +174,7 @@ async function loadFEDS() {
       || !replacedCategory
       || !validSecondPathSegments.includes(replacedCategory)
       || locale !== 'us') { // Remove this line once locale translations are complete
-      return undefined;
+      return null;
     }
 
     const secondBreadCrumb = buildBreadCrumb(secondPathSegment, capitalize(replacedCategory), `${localePath}/express`);


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://jira.corp.adobe.com/browse/MWPW-132589

Test URLs:
- Before: https://template-list-revamp--express-website--adobe.hlx.page/express/templates/flyer/christmas
- After: https://template-v2-no-gnav-breadcrumbs--express-website--adobe.hlx.page/express/templates/flyer/christmas
