### PR TITLE
[MWPW-132530] Sticky promo bar: allow for in-line link

### DIFF
--- a/express/blocks/hero-animation-beta/hero-animation-beta.js
+++ b/express/blocks/hero-animation-beta/hero-animation-beta.js
@@ -235,7 +235,6 @@ export default async function decorate($block) {
       }
 
       const contentButtons = [...$div.querySelectorAll('a.button.accent')];
-      console.log(contentButtons);
       $bg.nextElementSibling.classList.add('display-style');
       const buttonAsLink = contentButtons[2];
       const secondaryButton = contentButtons[1];

--- a/express/blocks/hero-animation-beta/hero-animation-beta.js
+++ b/express/blocks/hero-animation-beta/hero-animation-beta.js
@@ -235,6 +235,7 @@ export default async function decorate($block) {
       }
 
       const contentButtons = [...$div.querySelectorAll('a.button.accent')];
+      console.log(contentButtons);
       $bg.nextElementSibling.classList.add('display-style');
       const buttonAsLink = contentButtons[2];
       const secondaryButton = contentButtons[1];

--- a/express/blocks/sticky-promo-bar/sticky-promo-bar.css
+++ b/express/blocks/sticky-promo-bar/sticky-promo-bar.css
@@ -35,6 +35,7 @@ main .sticky-promo-bar:not(.rounded) a:any-link {
 main .sticky-promo-bar.rounded a:any-link {
     color: white;
     text-decoration: underline;
+    white-space: nowrap;
 }
 
 main .sticky-promo-bar.rounded p {

--- a/express/blocks/sticky-promo-bar/sticky-promo-bar.css
+++ b/express/blocks/sticky-promo-bar/sticky-promo-bar.css
@@ -15,11 +15,10 @@ body[data-device="mobile"] main .sticky-promo-bar.rounded {
     border-radius: 10px;
     margin: 11px 24px 16px 24px;
     font-weight: 300;
-    padding-right: 22px;
-    padding: 12px 22px 17px 14px;
+    padding: 12px 24px 17px 24px;
 }
 
-main .sticky-promo-bar a:any-link {
+main .sticky-promo-bar:not(.rounded) a:any-link {
     color: white;
     border: 2px solid white;
     border-radius: 20px;
@@ -31,6 +30,18 @@ main .sticky-promo-bar a:any-link {
     white-space: nowrap;
     display: inline-block;
     margin-top: 5px;
+}
+
+main .sticky-promo-bar.rounded a:any-link {
+    color: white;
+    text-decoration: underline;
+}
+
+main .sticky-promo-bar.rounded p {
+    display: inline;
+    font-size: var(--body-font-size-m);
+    margin: 0;
+    line-height: normal;
 }
 
 main .sticky-promo-bar .close {

--- a/express/blocks/sticky-promo-bar/sticky-promo-bar.css
+++ b/express/blocks/sticky-promo-bar/sticky-promo-bar.css
@@ -36,6 +36,8 @@ main .sticky-promo-bar.rounded a:any-link {
     color: white;
     text-decoration: underline;
     white-space: nowrap;
+    font-style: initial;
+    font-weight: 300;
 }
 
 main .sticky-promo-bar.rounded p {

--- a/express/blocks/sticky-promo-bar/sticky-promo-bar.css
+++ b/express/blocks/sticky-promo-bar/sticky-promo-bar.css
@@ -37,7 +37,6 @@ main .sticky-promo-bar.rounded a:any-link {
     text-decoration: underline;
     white-space: nowrap;
     font-style: initial;
-    font-weight: 300;
 }
 
 main .sticky-promo-bar.rounded p {

--- a/express/blocks/sticky-promo-bar/sticky-promo-bar.js
+++ b/express/blocks/sticky-promo-bar/sticky-promo-bar.js
@@ -17,22 +17,22 @@ import {
 
 import BlockMediator from '../../scripts/block-mediator.js';
 
-export default function decorate($block) {
-  const $close = createTag('button', {
+export default function decorate(block) {
+  const close = createTag('button', {
     class: 'close',
     'aria-label': 'close',
   });
-  $block.appendChild($close);
+  block.appendChild(close);
 
   BlockMediator.set('promobar', {
-    block: $block,
+    block: block,
     rendered: true,
   });
 
-  $close.addEventListener('click', () => {
-    $block.remove();
+  close.addEventListener('click', () => {
+    block.remove();
     BlockMediator.set('promobar', {
-      block: $block,
+      block: block,
       rendered: false,
     });
   });


### PR DESCRIPTION
Fix: https://jira.corp.adobe.com/browse/MWPW-132530

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/drafts/casey/beta-homepage/beta?lighthouse=on
- After: https://mwpw-132530--express-website--wbstry.hlx.page/drafts/casey/beta-homepage/beta?lighthouse=on

Updated CTA to show up as an in-line hyperlink, also removed '$' variables from the JS file.