### PR TITLE
[MWPW-129863] stop expecting ratios to always be specified

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -1400,10 +1400,10 @@ function toggleMasonryView($block, $button, $toggleButtons, props) {
   }
 
   const placeholder = $block.querySelector('.template.placeholder');
-  const ratios = props.placeholderFormat;
+  const ratios = props.placeholderFormat ? props.placeholderFormat : getMetadata('placeholder-format');
   const width = getPlaceholderWidth($block);
 
-  if (ratios[1]) {
+  if (ratios && ratios[1]) {
     const height = (ratios[1] / ratios[0]) * width;
     placeholder.style = `height: ${height - 21}px`;
     if (width / height > 1.3) {


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix MWPW-129863-2

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/templates/search?tasks=facebook%20post&phformat=2:3&topics=christmas
- After: https://mwpw-129863-2--express-website--adobe.hlx.page/express/templates/search?tasks=facebook%20post&phformat=2:3&topics=christmas
