### PR TITLE
[MWPW-133097] Long Text Block - 1st Iteration

### DIFF
--- a/express/blocks/long-text/long-text.css
+++ b/express/blocks/long-text/long-text.css
@@ -1,7 +1,31 @@
-main .long-text-wrapper {
+main .section div.long-text-wrapper {
     max-width: none;
+    padding: 0;
 }
 
 main .long-text {
-    max-width: 760px;
+    margin: 0 28px;
+    padding: 28px;
+    background-color: var(--color-gray-100);
+    border-radius: 20px;
+}
+
+main .long-text h2,
+main .long-text p {
+    text-align: left;
+}
+
+main .long-text h2 {
+    font-size: var(--heading-font-size-m);
+}
+
+main .long-text p {
+    font-size: var(--body-font-size-s);
+}
+
+@media (min-width: 900px) {
+    main .long-text {
+        margin: 0 60px;
+        padding: 28px;
+    }
 }

--- a/express/blocks/long-text/long-text.css
+++ b/express/blocks/long-text/long-text.css
@@ -1,0 +1,7 @@
+main .long-text-wrapper {
+    max-width: none;
+}
+
+main .long-text {
+    max-width: 760px;
+}

--- a/express/blocks/long-text/long-text.css
+++ b/express/blocks/long-text/long-text.css
@@ -1,3 +1,4 @@
+/* to remove after wrapper deprecation */
 main .section div.long-text-wrapper {
     max-width: none;
     padding: 0;

--- a/express/blocks/long-text/long-text.js
+++ b/express/blocks/long-text/long-text.js
@@ -12,6 +12,10 @@
 
 export default function decorate(block) {
   if (block.textContent.trim() === '') {
-    block.parentElement.remove();
+    if (block.parentElement.classList.contains('long-text-wrapper')) {
+      block.parentElement.remove();
+    } else {
+      block.remove();
+    }
   }
 }

--- a/express/blocks/long-text/long-text.js
+++ b/express/blocks/long-text/long-text.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export default function decorate(block) {
+  if (block.textContent.trim() === '') {
+    block.parentElement.remove();
+  }
+}


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix [MWPW-133097](https://jira.corp.adobe.com/browse/MWPW-133097)

**Description:**
A barebone version of the long-text block. If neither a heading or a paragraph is authored (the entire block having no text), the block will remove either the wrapper, or the block itself if the immediate parent is the section container.

**Test URLs:**
- Before: https://template-list-revamp--express-website--adobe.hlx.page/express/templates/search?tasks=banner&phformat=2:3&topics=christmas
- After: https://mwpw-133097--express-website--wbstry.hlx.page/express/templates/search?tasks=banner&phformat=2:3&topics=christmas
- After (no content from metadata): https://mwpw-133097--express-website--wbstry.hlx.page/fr/express/templates/search?tasks=banner&phformat=2:3&topics=christmas
