### PR TITLE
[To Stage] Template v2 fixes

### DIFF
--- a/express/blocks/browse-by-category/browse-by-category.css
+++ b/express/blocks/browse-by-category/browse-by-category.css
@@ -193,10 +193,10 @@ main .browse-by-category-wrapper.fullwidth {
   }
   
   @media (min-width: 900px) {
-  main .browse-by-category-wrapper .browse-by-category {
+  main .section .browse-by-category-wrapper {
     padding: 0 28px;
     max-width: none;
-    }
+  }
     
   main .browse-by-category .browse-by-category-heading-section {
     flex-direction: row;

--- a/express/blocks/browse-by-category/browse-by-category.css
+++ b/express/blocks/browse-by-category/browse-by-category.css
@@ -195,11 +195,14 @@ main .browse-by-category-wrapper.fullwidth {
   @media (min-width: 900px) {
   main .section .browse-by-category-wrapper {
     padding: 0 28px;
+  }
+
+  main .section .browse-by-category-wrapper {
     max-width: none;
   }
     
   main .browse-by-category .browse-by-category-heading-section {
-    flex-direction: row;
-    padding: 0;
+      flex-direction: row;
+      padding: 0;
     }
   }

--- a/express/blocks/template-list/breadcrumbs.js
+++ b/express/blocks/template-list/breadcrumbs.js
@@ -32,8 +32,13 @@ function getCrumbsForSearch(templatesUrl, allTemplatesMetadata, taskCategories) 
   if (!tasks && !topics) {
     return crumbs;
   }
+  const shortTitle = getMetadata('short-title');
+  if (!shortTitle) {
+    return crumbs;
+  }
+
   const lastCrumb = createTag('li');
-  lastCrumb.textContent = getMetadata('short-title');
+  lastCrumb.textContent = shortTitle;
   crumbs.push(lastCrumb);
   if (!tasks || !topics) {
     return crumbs;

--- a/express/blocks/template-list/template-list.css
+++ b/express/blocks/template-list/template-list.css
@@ -2339,7 +2339,7 @@ main .template-list-fullwidth-apipowered-container nav ol.templates-breadcrumbs 
   main .template-list.horizontal .carousel-container {
     margin-left: auto;
     margin-right: auto;
-    max-width: 470px;
+    max-width: none;
     display: block;
   }
 

--- a/express/scripts/ckg-link-list.js
+++ b/express/scripts/ckg-link-list.js
@@ -292,7 +292,8 @@ function hideAsyncBlocks() {
 (async function updateAsyncBlocks() {
   hideAsyncBlocks();
   // TODO: integrate memoization
-  if (document.body.dataset.device === 'desktop' && ['yes', 'true', 'on', 'Y'].includes(getMetadata('show-search-marquee-link-list'))) {
+  const showSearchMarqueeLinkList = getMetadata('show-search-marquee-link-list');
+  if (document.body.dataset.device === 'desktop' && (!showSearchMarqueeLinkList || ['yes', 'true', 'on', 'Y'].includes(showSearchMarqueeLinkList))) {
     await lazyLoadSearchMarqueeLinklist();
   }
   await lazyLoadLinklist();


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/MWPW-133170

Fixed css of browse-by-category and template-list horizontal variant.
By default and unless falsy specified in metadata sheet, searchMarquee will show CKG pills
When short-title is missing, breadcrumbs won't have an empty lastCrumb

Test URLs:
- Before: https://stage--express-website--adobe.hlx.page/fr/express/
- After: https://template-v2-fixes--express-website--adobe.hlx.page/fr/express/
