### PR TITLE
[MWPW-113266] fstab clean up

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -6,23 +6,12 @@ folders:
   /express/templates/content.json: /metadata.json
   /express/templates/: /express/templates/default
   /br/express/templates/: /br/express/templates/default
-  /cn/express/templates/: /express/templates/default
   /de/express/templates/: /de/express/templates/default
-  /dk/express/templates/: /express/templates/default
   /es/express/templates/: /es/express/templates/default
-  /fi/express/templates/: /express/templates/default
   /fr/express/templates/: /fr/express/templates/default
   /it/express/templates/: /it/express/templates/default
   /jp/express/templates/: /jp/express/templates/default
   /kr/express/templates/: /kr/express/templates/default
   /nl/express/templates/: /nl/express/templates/default
-  /no/express/templates/: /express/templates/default
-  /se/express/templates/: /express/templates/default
   /tw/express/templates/: /tw/express/templates/default
-  /express/templates/search: /express/templates/search
-  /cn/express/templates/search: /express/templates/search
-  /dk/express/templates/search: /express/templates/search
-  /fi/express/templates/search: /express/templates/search
-  /no/express/templates/search: /express/templates/search
-  /se/express/templates/search: /express/templates/search
 


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix [mwpw-133266](https://jira.corp.adobe.com/browse/MWPW-133266)

**Description**
It's exposed that some rows in the fstab.yaml are obsolete. Here's a quick PR to remove them from the file.

**Test URLs:**
- Before: https://main--express-website--adobe.hlx.page/express/templates/flyer?lighthouse=on
- After: https://mwpw-133266--express-website--wbstry.hlx.page/express/templates/flyer?lighthouse=on
