### PR TITLE
[MWPW-133406] [HOTFIX]: Relevant Rows regression caused by template v2 release

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -1606,7 +1606,7 @@ export async function decorateTemplateList($block, props) {
         }
       }
 
-      if (placeholders['template-filter-premium']) {
+      if (placeholders['template-filter-premium'] && !$block.classList.contains('mini')) {
         document.addEventListener('linkspopulated', async (e) => {
           // desktop/mobile fires the same event
           if ($parent.contains(e.detail[0])) {


### PR DESCRIPTION
Fix [MWPW-133406](https://jira.corp.adobe.com/browse/MWPW-133406)

**Description:**
A regression caused by template v2 refactoring where the toolbar got rendered on relevant rows as well. This fix removes 'mini' version of the template-list from the toolbar rendering logic.

**Test URLs: (mobile only)**
Before: https://stage--express-website--adobe.hlx.page/express/create/agenda?lighthouse=on
After: https://mwpw-133406-hotfix--express-website--wbstry.hlx.page/express/create/agenda?lighthouse=on