### PR TITLE
[MWPW-133513] FR toolbar title case fix

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -90,7 +90,7 @@ async function populateHeadingPlaceholder(locale, props) {
       grammarTemplate.split(' ').forEach((word, index, words) => {
         if (index + 1 < words.length) {
           if (word === 'de' && wordStartsWithVowels(words[index + 1])) {
-            words.splice(index, 2, `d'${words[index + 1].toLowerCase()}`);
+            words.splice(index, 2, `d'${words[index + 1]}`);
             grammarTemplate = words.join(' ');
           }
         }


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix [MWPW-133513](https://jira.corp.adobe.com/browse/MWPW-133513)

**Description:**
Fix mistakenly hard-lowercased FR words in grammar template

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/fr/express/templates/?lighthouse=on
- After: https://mwpw-133513--express-website--wbstry.hlx.page/fr/express/templates/?lighthouse=on
