### PR TITLE
[MWPW-133739] Templates v2 Search Marquee: Launch search on prediction click

### DIFF
--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -129,6 +129,14 @@ function initSearchFunction(block) {
     await redirectSearch();
   };
 
+  async function handleSubmitInteraction(item) {
+    if (item.query !== searchBar.value) {
+      searchBar.value = item.query;
+      searchBar.dispatchEvent(new Event('input'));
+    }
+    await onSearchSubmit();
+  }
+
   searchForm.addEventListener('submit', async (e) => {
     e.preventDefault();
     await onSearchSubmit();
@@ -151,22 +159,12 @@ function initSearchFunction(block) {
         const valRegEx = new RegExp(searchBar.value, 'i');
         li.innerHTML = item.query.replace(valRegEx, `<b>${searchBarVal}</b>`);
         li.addEventListener('click', async () => {
-          if (item.query !== searchBar.value) {
-            searchBar.value = item.query;
-            searchBar.dispatchEvent(new Event('input'));
-          }
-
-          await onSearchSubmit();
+          await handleSubmitInteraction(item);
         });
 
         li.addEventListener('keydown', async (e) => {
           if (e.key === 'Enter' || e.keyCode === 13) {
-            if (item.query !== searchBar.value) {
-              searchBar.value = item.query;
-              searchBar.dispatchEvent(new Event('input'));
-            }
-
-            await onSearchSubmit();
+            await handleSubmitInteraction(item);
           }
         });
 

--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -159,6 +159,17 @@ function initSearchFunction(block) {
           await onSearchSubmit();
         });
 
+        li.addEventListener('keydown', async (e) => {
+          if (e.key === 'Enter' || e.keyCode === 13) {
+            if (item.query !== searchBar.value) {
+              searchBar.value = item.query;
+              searchBar.dispatchEvent(new Event('input'));
+            }
+
+            await onSearchSubmit();
+          }
+        });
+
         suggestionsList.append(li);
       });
     }

--- a/express/blocks/search-marquee/search-marquee.js
+++ b/express/blocks/search-marquee/search-marquee.js
@@ -123,11 +123,15 @@ function initSearchFunction(block) {
     }
   };
 
+  const onSearchSubmit = async () => {
+    searchBar.disabled = true;
+    logSearch(searchForm);
+    await redirectSearch();
+  };
+
   searchForm.addEventListener('submit', async (e) => {
     e.preventDefault();
-    searchBar.disabled = true;
-    logSearch(e.currentTarget);
-    await redirectSearch();
+    await onSearchSubmit();
   });
 
   clearBtn.addEventListener('click', () => {
@@ -146,10 +150,13 @@ function initSearchFunction(block) {
         const li = createTag('li', { tabindex: 0 });
         const valRegEx = new RegExp(searchBar.value, 'i');
         li.innerHTML = item.query.replace(valRegEx, `<b>${searchBarVal}</b>`);
-        li.addEventListener('click', () => {
-          if (item.query === searchBar.value) return;
-          searchBar.value = item.query;
-          searchBar.dispatchEvent(new Event('input'));
+        li.addEventListener('click', async () => {
+          if (item.query !== searchBar.value) {
+            searchBar.value = item.query;
+            searchBar.dispatchEvent(new Event('input'));
+          }
+
+          await onSearchSubmit();
         });
 
         suggestionsList.append(li);


### PR DESCRIPTION
Please always provide the [JIRA issue(s)](https://jira.corp.adobe.com/secure/RapidBoard.jspa?rapidView=34618) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix [MWPW-133739](https://jira.corp.adobe.com/browse/MWPW-133739)

**Description:**
Search Marquee will now launch search as soon as a prediction result is clicked
users can also use tab key and enter key to interact with the search results now

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/templates/?lighthouse=on
- After: https://mwpw-133739--express-website--wbstry.hlx.page/express/templates/?lighthouse=on
