### PR TITLE
Autocomplete only for EFGJ

### DIFF
--- a/express/blocks/search-marquee/autocomplete-api-v3.js
+++ b/express/blocks/search-marquee/autocomplete-api-v3.js
@@ -16,9 +16,10 @@ const scopeEntities = [
   'HzTemplate',
   // 'HzTextLockup', 'Icon', 'Photo', 'DesignAsset', 'Background'
 ];
+const wlLocales = ['en-US', 'fr-FR', 'de-DE', 'ja-JP'];
 const emptyRes = { queryResults: [{ items: [] }] };
 export default async function fetchAPI({ limit = 5, textQuery, locale = 'en-US' }) {
-  if (!textQuery) {
+  if (!textQuery || !wlLocales.includes(locale)) {
     return [];
   }
 


### PR DESCRIPTION
Fix https://jira.corp.adobe.com/browse/MWPW-134006

Test URLs:
- Before: https://main--express-website--adobe.hlx.page/express/templates/?lighthouse=on
- After: https://stage--express-website--adobe.hlx.page/express/templates/?lighthouse=on

Should have 0 impact on the Autocomplete for EFGJ languages
For all other languages, no network request should be sent for autocomplete, like in https://stage--express-website--adobe.hlx.page/es/express/templates/ 
